### PR TITLE
Give access to visitors for Collections and Items

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,10 +1,10 @@
 class CollectionsController < ApplicationController
+  skip_before_action :authenticate_user!, only: [ :index, :show ]
   before_action :set_collection, only: %i[ show edit update destroy ]
 
   # GET /collections or /collections.json
   def index
     @collections = Collection.all
-    authorize @collections
   end
 
   # GET /collections/1 or /collections/1.json

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  skip_before_action :authenticate_user!, only: [ :index, :show ]
   before_action :set_item, only: %i[ show ]
 
   # GET /items or /items.json

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -15,13 +15,9 @@
     </button>
     <!-- this is regular navbar-->
     <div class="collapse navbar-collapse d-none d-md-block">
-      <% if user_signed_in? %>
-        <%# if is_admin? || is_readonly? %>
-          <div class="nav-item dropdown navbar_dropdown_item h-100 px-2 rounded-0 border-0" style="--bs-focus-ring-color:#E5E5E5;">
-            <%= link_to "Collections", collections_path, class: 'nav-link h-100 d-flex align-items-center fs-5 focus-ring border-0 rounded-2' %>
-          </div>
-        <% end %>
-      <%# end %>
+      <div class="nav-item dropdown navbar_dropdown_item h-100 px-2 rounded-0 border-0" style="--bs-focus-ring-color:#E5E5E5;">
+        <%= link_to "Collections", collections_path, class: 'nav-link h-100 d-flex align-items-center fs-5 focus-ring border-0 rounded-2' %>
+      </div>
     </div>
   <!-- this is the hamburger menu-->
   <div class="collapse navbar-collapse d-md-none" id="navbarBurgerMenu">


### PR DESCRIPTION
Added skip_before_action to collections and items controller.

Authorizing users for index and show pages deemed unnecessary, so it was removed.

Visitors should now be able to view collections and items.