### PR TITLE
Lra 1109 add edit forms

### DIFF
--- a/app/controllers/loan_questions_controller.rb
+++ b/app/controllers/loan_questions_controller.rb
@@ -11,6 +11,7 @@ class LoanQuestionsController < ApplicationController
 
   # GET /loan_questions/1 or /loan_questions/1.json
   def show
+    @options = @loan_question.options.order(:position)
   end
 
   # GET /loan_questions/new
@@ -20,6 +21,7 @@ class LoanQuestionsController < ApplicationController
 
   # GET /loan_questions/1/edit
   def edit
+    @options = @loan_question.options.order(:position)
   end
 
   # POST /loan_questions or /loan_questions.json
@@ -56,13 +58,13 @@ class LoanQuestionsController < ApplicationController
           Rails.logger.info("Updating options for question: #{@loan_question.id}")
           Rails.logger.info("Params: #{params[:option_attributes].inspect}")
 
-          # Remove old options and recreate
-          @loan_question.options.destroy_all
-          Rails.logger.info("Old options destroyed.")
-
-          params[:option_attributes].values.each do |option_param|
-            Rails.logger.info("Creating option with value: #{option_param[:value]}")
-            @loan_question.options.create(value: option_param[:value])
+          params[:option_attributes].values.each_with_index do |option_param, index|
+            if option_param[:id].present?
+              option = @loan_question.options.find_by(id: option_param[:id])
+              option&.update(value: option_param[:value], position: index)
+            else
+              @loan_question.options.create(value: option_param[:value], position: index)
+            end
           end
         end
         format.html { redirect_to @loan_question, notice: "Loan question was successfully updated." }

--- a/app/javascript/controllers/edit_options_controller.js
+++ b/app/javascript/controllers/edit_options_controller.js
@@ -6,12 +6,14 @@ export default class extends Controller {
   
   connect() {
     console.log("Options controller connected");
+    this.showOnlyLastRemoveOptionButton();
   }
 
   append() {
     console.log("append called");
 
-    const thisOptionsNumber = document.querySelectorAll(".option-list-item").length;
+    const thisOptionsNumber = Array.from(document.querySelectorAll(".option-list-item"))
+                               .filter(item => item.style.display !== "none").length;
     const newOptionNumber = thisOptionsNumber + 1;
     console.log("thisOptionsNumber", thisOptionsNumber);
 
@@ -45,43 +47,65 @@ export default class extends Controller {
     this.fieldsTarget.appendChild(newOptionElement);
 
     this.showOnlyLastRemoveOptionButton();
+
+    this.renumberOptionLabels();
   }
 
   removeOption(event) {
     event.preventDefault();
 
-    const allOptions = document.querySelectorAll(".option-list-item");
+    const allOptionItems = Array.from(document.querySelectorAll(".option-list-item"));
+    const visibleOptions = allOptionItems.filter(item => item.style.display !== "none");
+
+    if (visibleOptions.length <= 2) return;
+
     const button = event.currentTarget;
     const optionItem = button.closest(".option-list-item");
 
-    if (allOptions.length <= 2) return;
+    // Only allow removing the last visible option
+    if (optionItem !== visibleOptions[visibleOptions.length - 1]) return;
+
+    const destroyField = optionItem.querySelector('input[name*="_destroy"]');
+    const idField = optionItem.querySelector('input[name*="[id]"]');
     
-    if (optionItem) {
+    if (destroyField && idField && idField.value) {
+      destroyField.value = "1";
+      destroyField.checked = true;
+      optionItem.style.display = "none";
+    } else {
       optionItem.remove();
-      this.showOnlyLastRemoveOptionButton();
     }
+
+    this.showOnlyLastRemoveOptionButton();
+
+    this.renumberOptionLabels();
   }
 
   showOnlyLastRemoveOptionButton() {
-    console.log("showOnlyLastRemoveOptionButton called");
-    let btns = document.querySelectorAll(".remove-option-button")
-    let btnsCount = btns.length -1;
-    console.log("btnsCount", btnsCount);
-    btns.forEach((btn, i) => {
-      // console.log("btn", btn);
-      // console.log("i", i);
-      if (i < 2) {
-        btn.classList.add("invisible");
-      } else if (i !== btnsCount) {
-        // console.log("not equal to btnsCount")
-        // console.log("i", i)
+    const allOptionItems = Array.from(document.querySelectorAll(".option-list-item"));
+    const visibleOptionItems = allOptionItems.filter(item => item.style.display !== "none");
+
+    const removeButtons = visibleOptionItems.map(item =>
+      item.querySelector(".remove-option-button")
+    );
+
+    removeButtons.forEach((btn, i) => {
+      if (i < 2 || i !== removeButtons.length - 1) {
         btn.classList.add("invisible");
       } else {
-        // console.log("equal to btnsCount")
-        // console.log("i", i)
-        // console.log("before", btn.classList)
         btn.classList.remove("invisible");
-        // console.log("after", btn.classList)
+      }
+    });
+  }
+
+  renumberOptionLabels() {
+    const visibleItems = Array.from(document.querySelectorAll(".option-list-item"))
+                              .filter(item => item.style.display !== "none");
+
+    visibleItems.forEach((item, index) => {
+      const label = item.querySelector('[data-edit-options-target="option_label"]');
+      if (label) {
+        label.textContent = `Option ${index + 1}`;
       }
     });
   }

--- a/app/javascript/controllers/edit_options_controller.js
+++ b/app/javascript/controllers/edit_options_controller.js
@@ -49,11 +49,13 @@ export default class extends Controller {
 
   removeOption(event) {
     event.preventDefault();
-    if (document.querySelectorAll(".option-list-item").length <= 2) return;
-    
+
+    const allOptions = document.querySelectorAll(".option-list-item");
     const button = event.currentTarget;
     const optionItem = button.closest(".option-list-item");
 
+    if (allOptions.length <= 2) return;
+    
     if (optionItem) {
       optionItem.remove();
       this.showOnlyLastRemoveOptionButton();

--- a/app/models/loan_question.rb
+++ b/app/models/loan_question.rb
@@ -10,7 +10,7 @@
 #
 class LoanQuestion < ApplicationRecord
   has_many :options, dependent: :destroy
-  accepts_nested_attributes_for :options
+  accepts_nested_attributes_for :options, allow_destroy: true
 
   enum :question_type, [:text, :dropdown, :checkbox], prefix: true
   validates :question, presence: true

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -3,6 +3,7 @@
 # Table name: options
 #
 #  id               :bigint           not null, primary key
+#  position         :integer
 #  value            :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/app/views/loan_questions/_edit_form.html.erb
+++ b/app/views/loan_questions/_edit_form.html.erb
@@ -1,51 +1,75 @@
-<%= form_with(model: loan_question, data: {controller: "edit-options"}) do |form| %>
+<%= form_with(model: loan_question, local: true, data: { controller: "edit-options" }) do |form| %>
   <% if loan_question.errors.any? %>
     <div style="color: red">
-      <h2><%= pluralize(loan_question.errors.count, "error") %> prohibited this loan_question from being saved:</h2>
-
+      <h2><%= pluralize(loan_question.errors.count, "error") %> prohibited this loan question from being saved:</h2>
       <ul>
-        <% loan_question.errors.each do |error| %>
-          <li><%= error.full_message %></li>
+        <% loan_question.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
         <% end %>
       </ul>
     </div>
   <% end %>
 
-  <div>
+  
+  <div class="mb-3">
     <%= form.label :question, class: "form-label" %>
-    <%= form.text_field :question, required: true, class: "input_text_field"  %>
+    <%= form.text_field :question, required: true, class: "form-control" %>
   </div>
 
-  <p>
-    <strong>Question type:</strong>
-    <%= loan_question.question_type %>
-  </p>
+  
+  <div class="mb-3">
+    <%= form.label :question_type, class: "form-label" %>
+    <%= text_field_tag :question_type_display, loan_question.question_type.humanize, class: "form-control", disabled: true %>
+    <%= form.hidden_field :question_type %>
+  </div>
 
-   <% @loan_question.options.each do |option| %>
-    <p>
-      <%= fields_for 'options[]', option, index: "option_#{option.id}" do |form| %>
-        <div class="mx-3">
-          <%= form.label :value, "Option" %> (<%= button_tag "Remove", type: :button, class: "btn btn-sm", data: {action: "edit-options#remove"} %>)
-          <%= form.text_field :value, required: true, class: "input_text_field" %>
-        </div>
-      <% end %>
-    </p>
+  
+  <% if loan_question.question_type.in?(%w[dropdown checkbox]) %>
+    <div class="mb-3">
+      <h5>Options</h5>
+
+      
+      <div data-edit-options-target="fields">
+        <% loan_question.options.each_with_index do |option, index| %>
+          <%= form.fields_for :options, option do |option_form| %>
+            <div class="option-list-item mb-2">
+              <%= option_form.label :value, "Option #{index + 1}", class: "form-label", data: { edit_options_target: "option_label" } %>
+              <%= option_form.text_field :value, class: "form-control", data: { edit_options_target: "option_value" } %>
+              <%= option_form.hidden_field :id %>
+              <%= option_form.check_box :_destroy, class: "d-none", data: { edit_options_target: "destroy_field" } %>
+
+              <button type="button"
+                      class="btn btn-sm btn-danger remove-option-button mt-1"
+                      data-edit-options-target="remove_button"
+                      data-action="edit-options#removeOption">
+                Remove
+              </button>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+      <button type="button" class="btn btn-sm btn-secondary mt-2"
+              data-action="edit-options#append"
+              data-edit-options-target="add_option_button">
+          Add Option
+      </button>
+    </div>
   <% end %>
 
-  <div id="options" data-edit-options-target="fields"></div>
+  <%= form.submit "Update Loan Question", class: "btn btn-primary mt-3" %>
 
-  <%= button_tag "Add Option", type: :button, class: "btn btn-sm", data: {action: "edit-options#append"} %>
-  <div class="invisible" data-edit-options-target="show_options">
-    
-
-    <template data-edit-options-target="template">
-      <%= fields_for 'options[]', Option.new, index: "__INDEX__" do |form| %>
-        <%= render "loan_questions/option_value", form: form %>
-      <% end %>
-    </template>
-  </div>
-
-  <div>
-    <%= form.submit %>
-  </div>
+  <template data-edit-options-target="template">
+    <div class="option-list-item mb-2">
+      <label class="form-label" data-edit-options-target="option_label">Option</label>
+      <input type="text" class="form-control" data-edit-options-target="option_value" />
+      <input type="hidden" data-edit-options-target="option_number" />
+      <button type="button"
+              class="btn btn-sm btn-danger remove-option-button mt-1"
+              data-edit-options-target="remove_button"
+              data-action="edit-options#removeOption">
+        Remove
+      </button>
+    </div>
+  </template>
 <% end %>

--- a/db/migrate/20250530205307_add_position_to_options.rb
+++ b/db/migrate/20250530205307_add_position_to_options.rb
@@ -1,0 +1,5 @@
+class AddPositionToOptions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :options, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_28_230351) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_30_205307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -155,6 +155,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_28_230351) do
     t.datetime "updated_at", null: false
     t.string "value"
     t.bigint "loan_question_id", null: false
+    t.integer "position"
     t.index ["loan_question_id"], name: "index_options_on_loan_question_id"
   end
 

--- a/spec/factories/options.rb
+++ b/spec/factories/options.rb
@@ -3,6 +3,7 @@
 # Table name: options
 #
 #  id               :bigint           not null, primary key
+#  position         :integer
 #  value            :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -3,6 +3,7 @@
 # Table name: options
 #
 #  id               :bigint           not null, primary key
+#  position         :integer
 #  value            :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null


### PR DESCRIPTION
- Ensured only the last visible option can be removed
- Enforced a minimum of 2 options per question (cannot remove below that)
- Used display: none + _destroy = 1 to properly mark existing options for deletion
- Updated Stimulus controller to:
    1) Dynamically show/remove the last option’s "Remove" button only.
    2) Recalculate and renumber option labels after add/remove actions.
    3) Correctly label new options based on the number of visible options (skips hidden ones).
- Added connect() lifecycle hook to initialize correct remove button state on form load