### PR TITLE
Lra 1136 bio repository address advanced search unique i ds and labels and case insensitive search

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,6 +16,15 @@ class ItemsController < ApplicationController
   end
 
   def search
+    if params[:q] && params[:q][:dynamic_fields]
+      params[:q][:dynamic_fields].each do |field_hash|
+        field = field_hash[:field]
+        value = field_hash[:value]
+        next if field.blank? || value.blank?
+
+        params[:q][field] = value
+      end
+    end
     @q = Item.ransack(params[:q])
     @items = @q.result.page(params[:page]).per(15)
     @collections =  @items.map { |i| i.collection.division}.uniq.join(', ')

--- a/app/views/layouts/_advance_search.html.erb
+++ b/app/views/layouts/_advance_search.html.erb
@@ -53,7 +53,7 @@
           <%else%>
             <% @countries.each do |country| %>
               <div class="form-check">
-                <%= check_box_tag "q[country_in][]", country, params.dig(:q, :country_in)&.include?(country), id: "country_#{country}" %>
+                <%= check_box_tag "q[country_i_matches_any][]", country, params.dig(:q, :country_i_matches_any)&.include?(country), id: "country_#{country.parameterize}" %>
                 <%= label_tag "q_country_in_#{country.parameterize}", country %>
               </div>
             <% end %>
@@ -71,9 +71,10 @@
             <p>No states or provinces available to select from.</p>
           <%else%>
             <% @states.each do |state| %>
+              <% state_id = "state_#{state.parameterize}" %>
               <div class="form-check">
-                <%= check_box_tag "q[state_province_in][]", state, params.dig(:q, :state_province_in)&.include?(state), id: "state_#{state}" %>
-                <%= label_tag "q_state_province_in_#{state.parameterize}", state %>
+                <%= check_box_tag "q[state_province_i_matches_any][]", state, params.dig(:q, :state_province_i_matches_any)&.include?(state), id: state_id %>
+                <%= label_tag state_id, state %>
               </div>
             <% end %>
           <% end %>
@@ -90,9 +91,10 @@
             <p>No sex options available to select from.</p>
           <% else %>
             <% @sexs.each do |sex| %>
+              <% sex_id = "sex_#{sex.parameterize}" %>
               <div class="form-check">
-                <%= check_box_tag "q[sex_in][]", sex, params.dig(:q, :sex_in)&.include?(sex), id: "sex_#{sex.parameterize}" %>
-                <%= label_tag "q_sex_in_#{sex.parameterize}", sex %>
+                <%= check_box_tag "q[sex_i_matches_any][]", sex, params.dig(:q, :sex_i_matches_any)&.include?(sex), id: sex_id %>
+                <%= label_tag sex_id, sex %>
               </div>
             <% end %>
           <% end %>
@@ -107,9 +109,10 @@
         <div id="continent-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
           <%if @continents.present?%>
             <% @continents.each do |continent| %>
+              <% continent_id = "continent_#{continent.parameterize}" %>
               <div class="form-check">
-                <%= check_box_tag "q[continent_in][]", continent, params.dig(:q, :continent_in)&.include?(continent), id: "continent_#{continent.parameterize}" %>
-                <%= label_tag "continent_#{continent.parameterize}", continent %>
+                <%= check_box_tag "q[continent_i_matches_any][]", continent, params.dig(:q, :continent_i_matches_any)&.include?(continent), id: continent_id %>
+                <%= label_tag continent_id, continent %>
               </div>
             <% end %>
           <% else %>

--- a/app/views/layouts/_advance_search.html.erb
+++ b/app/views/layouts/_advance_search.html.erb
@@ -4,7 +4,7 @@
 
     <!-- Strings - use _i_cont (contains) or _eq (exact match) -->
     <div class="mb-3">
-      <h5>Select Collections:</h5>
+      <h4>Select Collections:</h4>
       <div class="btn-group btn-group-toggle flex-wrap" data-toggle="buttons">
         <% @all_collections.each do |collection| %>
           <label class="btn btn-outline-primary m-1">
@@ -43,82 +43,99 @@
 
     <div class="row">
       <div class="col-md-6 mb-3">
-        <h5>Country or Region</h5>
-        <small>Select one or more countries or regions to narrow your results</small>
-        <input type="text" class="form-control my-2" placeholder="Filter" onkeyup="filterCheckboxes('country-filters', this.value)">
+        <fieldset class="mb-3" id="country-filter-group">
+          <legend class="h5">Country or Region</legend>
+          <small>Select one or more countries or regions to narrow your results</small>
+          <label for="country-filter" class="visually-hidden">Filter Countries</label>
+          <input id="country-filter" type="text" class="form-control my-2" placeholder="Filter" onkeyup="filterCheckboxes('country-filters', this.value)">
 
-        <div id="country-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
-          <% if @countries.blank? %>
-            <p>No countries available to select from.</p>
-          <%else%>
-            <% @countries.each do |country| %>
-              <div class="form-check">
-                <%= check_box_tag "q[country_i_matches_any][]", country, params.dig(:q, :country_i_matches_any)&.include?(country), id: "country_#{country.parameterize}" %>
-                <%= label_tag "q_country_in_#{country.parameterize}", country %>
-              </div>
+          <div id="country-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
+            <% if @countries.blank? %>
+              <p>No countries available to select from.</p>
+            <%else%>
+              <% @countries.each do |country| %>
+                <% country_id = "country_#{country.parameterize}" %>
+                <div class="form-check">
+                  <%= check_box_tag "q[country_i_matches_any][]", country,
+                        params.dig(:q, :country_i_matches_any)&.include?(country),
+                        id: country_id %>
+                  <%= label_tag country_id, country %>
+                </div>
+              <% end %>
             <% end %>
-          <% end %>
-        </div>
+          </div>
+        </fieldset>
       </div>
 
       <div class="col-md-6 mb-3">
-        <h5>State / Province</h5>
-        <small>Select one or more states or provinces to narrow your results</small>
-        <input type="text" class="form-control my-2" placeholder="Filter" onkeyup="filterCheckboxes('state-filters', this.value)">
+        <fieldset class="mb-3" id="state-province-filter-group">
+          <legend class="h5">State / Province</legend>
+          <small>Select one or more states or provinces to narrow your results</small>
+          <label for="state-province-filter" class="visually-hidden">Filter State / Province</label>
+          <input id="state-province-filter" type="text" class="form-control my-2" placeholder="Filter" onkeyup="filterCheckboxes('state-filters', this.value)">
 
-        <div id="state-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
-          <% if @states.blank? %>
-            <p>No states or provinces available to select from.</p>
-          <%else%>
-            <% @states.each do |state| %>
-              <% state_id = "state_#{state.parameterize}" %>
-              <div class="form-check">
-                <%= check_box_tag "q[state_province_i_matches_any][]", state, params.dig(:q, :state_province_i_matches_any)&.include?(state), id: state_id %>
-                <%= label_tag state_id, state %>
-              </div>
+          <div id="state-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
+            <% if @states.blank? %>
+              <p>No states or provinces available to select from.</p>
+            <%else%>
+              <% @states.each do |state| %>
+                <% state_id = "state_#{state.parameterize}" %>
+                <div class="form-check">
+                  <%= check_box_tag "q[state_province_i_matches_any][]", state,
+                        params.dig(:q, :state_province_i_matches_any)&.include?(state),
+                        id: state_id %>
+                  <%= label_tag state_id, state %>
+                </div>
+              <% end %>
             <% end %>
-          <% end %>
-        </div>
+          </div>
+        </fieldset>
       </div>
 
       <div class="col-md-6 mb-3">
-        <h5>Sex</h5>
-        <small>Select sex to narrow your results</small>
-        <input type="text" class="form-control my-2" placeholder="Filter" onkeyup="filterCheckboxes('sex-filters', this.value)">
+        <fieldset class="mb-3" id="sex-filter-group">
+          <legend class="h5">Sex</legend>
+          <small>Select sex to narrow your results</small>
+          <label for="sex-filter" class="visually-hidden">Filter Sex</label>
+          <input id="sex-filter" type="text" class="form-control my-2" placeholder="Filter" onkeyup="filterCheckboxes('sex-filters', this.value)">
 
-        <div id="sex-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
-          <% if @sexs.blank? %>
-            <p>No sex options available to select from.</p>
-          <% else %>
-            <% @sexs.each do |sex| %>
-              <% sex_id = "sex_#{sex.parameterize}" %>
-              <div class="form-check">
-                <%= check_box_tag "q[sex_i_matches_any][]", sex, params.dig(:q, :sex_i_matches_any)&.include?(sex), id: sex_id %>
-                <%= label_tag sex_id, sex %>
-              </div>
+          <div id="sex-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
+            <% if @sexs.blank? %>
+              <p>No sex options available to select from.</p>
+            <% else %>
+              <% @sexs.each do |sex| %>
+                <% sex_id = "sex_#{sex.parameterize}" %>
+                <div class="form-check">
+                  <%= check_box_tag "q[sex_i_matches_any][]", sex, params.dig(:q, :sex_i_matches_any)&.include?(sex), id: sex_id %>
+                  <%= label_tag sex_id, sex %>
+                </div>
+              <% end %>
             <% end %>
-          <% end %>
-        </div>
+          </div>
+        </fieldset>
       </div>
 
       <div class="col-md-6 mb-3">
-        <h5>Continent</h5>
-        <small>Select one or more continents to narrow your results</small>
-        <input type="text" class="form-control my-2" placeholder="Filter" onkeyup="filterCheckboxes('continent-filters', this.value)">
+        <fieldset class="mb-3" id="continent-filter-group">
+          <legend class="h5">Continent</legend>
+          <small>Select one or more continents to narrow your results</small>
+          <label for="continent-filter" class="visually-hidden">Filter continent</label>
+          <input id="continent-filter" type="text" class="form-control my-2" placeholder="Filter" onkeyup="filterCheckboxes('continent-filters', this.value)">
 
-        <div id="continent-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
-          <%if @continents.present?%>
-            <% @continents.each do |continent| %>
-              <% continent_id = "continent_#{continent.parameterize}" %>
-              <div class="form-check">
-                <%= check_box_tag "q[continent_i_matches_any][]", continent, params.dig(:q, :continent_i_matches_any)&.include?(continent), id: continent_id %>
-                <%= label_tag continent_id, continent %>
-              </div>
+          <div id="continent-filters" style="max-height: 200px; overflow-y: auto; border: 1px solid #ccc; padding: 8px;">
+            <%if @continents.present?%>
+              <% @continents.each do |continent| %>
+                <% continent_id = "continent_#{continent.parameterize}" %>
+                <div class="form-check">
+                  <%= check_box_tag "q[continent_i_matches_any][]", continent, params.dig(:q, :continent_i_matches_any)&.include?(continent), id: continent_id %>
+                  <%= label_tag continent_id, continent %>
+                </div>
+              <% end %>
+            <% else %>
+              <p>No continent available to select from.</p>
             <% end %>
-          <% else %>
-            <p>No continent available to select from.</p>
-          <% end %>
-        </div>
+          </div>
+        </fieldset>
       </div>
     </div>
     <div>

--- a/app/views/layouts/_advance_search.html.erb
+++ b/app/views/layouts/_advance_search.html.erb
@@ -21,7 +21,13 @@
       <div id="groups-container" data-search-target="groupsContainer">
         <div data-search-target="group" class="search-group mb-3 p-3 rounded border border-primary">
           <div data-search-target="rows">
-            <%= render partial: "layouts/search_field" %>
+            <% if params.dig(:q, :dynamic_fields).present? %>
+              <% params[:q][:dynamic_fields].each do |row| %>
+                <%= render partial: "layouts/search_field", locals: { selected_field: row[:field], entered_value: row[:value] } %>
+              <% end %>
+            <% else %>
+              <%= render partial: "layouts/search_field", locals: { selected_field: nil, entered_value: nil } %>
+            <% end %>
           </div>
 
           <button type="button" class="btn btn-outline-primary mt-1" data-action="click->search#addRow">+ Add Field</button>
@@ -31,7 +37,7 @@
       <template data-search-target="groupTemplate">
         <div data-search-target="group" class="search-group mb-3 p-3 rounded border border-primary">
           <div data-search-target="rows">
-            <%= render partial: "layouts/search_field" %>
+            <%= render partial: "layouts/search_field", locals: { selected_field: nil, entered_value: nil } %>
           </div>
 
           <button type="button" class="btn btn-outline-primary mt-1" data-action="click->search#addRow">+ Add Field</button>

--- a/app/views/layouts/_search_field.html.erb
+++ b/app/views/layouts/_search_field.html.erb
@@ -1,4 +1,6 @@
 <div class="search-row d-flex align-items-center mb-2" data-search-target="row">
+	<% select_id = "search_field_#{SecureRandom.hex(4)}" %>
+  <label for="<%= select_id %>" class="form-label me-2">Search Field</label>
   <%= select_tag "", options_for_select([
     ["Associated Sequences", "associated_sequences_i_cont"],
 		["Catalog Number", "catalog_number_eq"],
@@ -22,9 +24,11 @@
 		["Verbatim Locality", "verbatim_locality_i_cont"],
 		["Vitality", "vitality_i_cont"]
      
-  ]), class: "form-select me-2 dynamic-search-field" %>
+  ]), id: select_id, class: "form-select me-2 dynamic-search-field" %>
 
-  <%= text_field_tag "", nil, class: "form-control me-2 dynamic-search-value" %>
-
+  <%= text_field_tag "", nil,
+        class: "form-control me-2 dynamic-search-value",
+        aria: { label: "Search value" } %>
+        
   <button type="button" class="btn btn-outline-danger" data-action="click->search#removeField" aria-label="Remove search field">✕</button>
 </div>

--- a/app/views/layouts/_search_field.html.erb
+++ b/app/views/layouts/_search_field.html.erb
@@ -1,34 +1,41 @@
 <div class="search-row d-flex align-items-center mb-2" data-search-target="row">
-	<% select_id = "search_field_#{SecureRandom.hex(4)}" %>
-  <label for="<%= select_id %>" class="form-label me-2">Search Field</label>
-  <%= select_tag "", options_for_select([
-    ["Associated Sequences", "associated_sequences_i_cont"],
-		["Catalog Number", "catalog_number_eq"],
-    ["County", "county_i_cont"],
-		["Event Remarks", "event_remarks_i_cont"],
-		["field_number", "field_number_i_cont"],
-    ["Geodetic Datum", "geodetic_datum_i_cont"],
-		["Georeference Protocol", "georeference_protocol_i_cont"],
-    ["Georeferenced By", "georeferenced_by_i_cont"],
-		["Life Stage", "life_stage_i_cont"],
-		["Locality", "locality_i_cont"],
-		["Occurrence Remarks", "occurrence_remarks_i_cont"],
-		["Organism Remarks", "organism_remarks_i_cont"],
-		["Other Catalog Numbers", "other_catalog_numbers_i_cont"],
-		["Recorded by", "recorded_by_i_cont"],
-		["Reproductive Condition", "reproductive_condition_i_cont"],
-		["Sampling Protocol", "sampling_protocol_i_cont"],
-		["Verbatim Coordinates", "verbatim_coordinates_i_cont"],
-		["Verbatim Elevation", "verbatim_elevation_i_cont"],
-		["Verbatim Event Date", "verbatim_event_date_i_cont"],
-		["Verbatim Locality", "verbatim_locality_i_cont"],
-		["Vitality", "vitality_i_cont"]
-     
-  ]), id: select_id, class: "form-select me-2 dynamic-search-field" %>
+<% select_id = "search_field_#{SecureRandom.hex(4)}" %>
+<label for="<%= select_id %>" class="form-label me-2">Search Field</label>
 
-  <%= text_field_tag "", nil,
-        class: "form-control me-2 dynamic-search-value",
-        aria: { label: "Search value" } %>
+<%= select_tag "q[dynamic_fields][][field]",
+  options_for_select([
+    ["Associated Sequences", "associated_sequences_i_cont"],
+    ["Catalog Number", "catalog_number_eq"],
+    ["County", "county_i_cont"],
+    ["Event Remarks", "event_remarks_i_cont"],
+    ["field_number", "field_number_i_cont"],
+    ["Geodetic Datum", "geodetic_datum_i_cont"],
+    ["Georeference Protocol", "georeference_protocol_i_cont"],
+    ["Georeferenced By", "georeferenced_by_i_cont"],
+    ["Life Stage", "life_stage_i_cont"],
+    ["Locality", "locality_i_cont"],
+    ["Occurrence Remarks", "occurrence_remarks_i_cont"],
+    ["Organism Remarks", "organism_remarks_i_cont"],
+    ["Other Catalog Numbers", "other_catalog_numbers_i_cont"],
+    ["Recorded by", "recorded_by_i_cont"],
+    ["Reproductive Condition", "reproductive_condition_i_cont"],
+    ["Sampling Protocol", "sampling_protocol_i_cont"],
+    ["Verbatim Coordinates", "verbatim_coordinates_i_cont"],
+    ["Verbatim Elevation", "verbatim_elevation_i_cont"],
+    ["Verbatim Event Date", "verbatim_event_date_i_cont"],
+    ["Verbatim Locality", "verbatim_locality_i_cont"],
+    ["Vitality", "vitality_i_cont"],
+  ],
+  selected_field
+),
+  id: select_id,
+  class: "form-select me-2 dynamic-search-field"
+%>
+
+<%= text_field_tag "q[dynamic_fields][][value]",
+  entered_value,
+  class: "form-control me-2 dynamic-search-value",
+  aria: { label: "Search Value" } %>
         
   <button type="button" class="btn btn-outline-danger" data-action="click->search#removeField" aria-label="Remove search field">✕</button>
 </div>


### PR DESCRIPTION
- Added Case Insensitive Search for the input fields for Advanced Search
- Input fields should all have unique IDs and labels, with the WAVE errors all addressed
- Assuming we reverted back to having to click the search button for advanced search from automatically showing results from user input, user input should all be retained after users click search