### PR TITLE
Add ActiveRecord::QueryCanceled Error handling to application controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,11 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
   include Pundit::Authorization
-  # unless Rails.env.development?
+  unless Rails.env.development?
     rescue_from StandardError, with: :render_500
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
     rescue_from ActiveRecord::QueryCanceled, with: :render_503
-  # end
+  end
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,11 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
   include Pundit::Authorization
-  unless Rails.env.development?
+  # unless Rails.env.development?
     rescue_from StandardError, with: :render_500
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
-  end
+    rescue_from ActiveRecord::QueryCanceled, with: :render_503
+  # end
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
@@ -52,6 +53,29 @@ class ApplicationController < ActionController::Base
       # If rendering the error page fails, fall back to a simple response
       Rails.logger.error "Error rendering error page: #{e.message}"
       render plain: "Internal Server Error", status: :internal_server_error
+    ensure
+      @handling_error = false
+    end
+  end
+
+  def render_503(exception)
+    # Prevent infinite loops by checking if we're already handling an error
+    return if @handling_error
+    @handling_error = true
+    
+    # Log the error for debugging
+    Rails.logger.error "Service Unavailable: #{exception.class} - #{exception.message}"
+    Rails.logger.error exception.backtrace.join("\n") if exception.backtrace
+    
+    begin
+      respond_to do |format|
+        format.html { render 'errors/service_unavailable_error', status: :service_unavailable, layout: 'application' }
+        format.json { render json: { error: 'Service Unavailable' }, status: :service_unavailable }
+      end
+    rescue => e
+      # If rendering the error page fails, fall back to a simple response
+      Rails.logger.error "Error rendering error page: #{e.message}"
+      render plain: "Service Unavailable", status: :service_unavailable
     ensure
       @handling_error = false
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,10 @@ class ApplicationController < ActionController::Base
 
   def render_500(exception)
     # Prevent infinite loops by checking if we're already handling an error
-    return if @handling_error
+    if @handling_error
+      Rails.logger.error "Error while already handling an error in render_500"
+      return render plain: "Internal Server Error", status: :internal_server_error
+    end
     @handling_error = true
     
     # Log the error for debugging
@@ -60,7 +63,10 @@ class ApplicationController < ActionController::Base
 
   def render_503(exception)
     # Prevent infinite loops by checking if we're already handling an error
-    return if @handling_error
+    if @handling_error
+      Rails.logger.error "Error while already handling an error in render_503"
+      return render plain: "Service Unavailable", status: :service_unavailable
+    end
     @handling_error = true
     
     # Log the error for debugging

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,11 @@
 class ApplicationController < ActionController::Base
   include ApplicationHelper
   include Pundit::Authorization
-  unless Rails.env.development?
+  # unless Rails.env.development?
     rescue_from StandardError, with: :render_500
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
     rescue_from ActiveRecord::QueryCanceled, with: :render_503
-  end
+  # end
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
 
   def render_404
     respond_to do |format|
-      format.html { render 'errors/not_found', status: :not_found, layout: 'application' }
+      format.html { render 'errors/not_found', status: :not_found, layout: false }
       format.json { render json: { error: 'Not Found' }, status: :not_found }
     end
   end
@@ -46,7 +46,7 @@ class ApplicationController < ActionController::Base
     
     begin
       respond_to do |format|
-        format.html { render 'errors/internal_server_error', status: :internal_server_error, layout: 'application' }
+        format.html { render 'errors/internal_server_error', status: :internal_server_error, layout: false }
         format.json { render json: { error: 'Internal Server Error' }, status: :internal_server_error }
       end
     rescue => e
@@ -69,7 +69,7 @@ class ApplicationController < ActionController::Base
     
     begin
       respond_to do |format|
-        format.html { render 'errors/service_unavailable_error', status: :service_unavailable, layout: 'application' }
+        format.html { render 'errors/service_unavailable_error', status: :service_unavailable, layout: false }
         format.json { render json: { error: 'Service Unavailable' }, status: :service_unavailable }
       end
     rescue => e

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
 
   def render_404
     respond_to do |format|
-      format.html { render 'errors/not_found', status: :not_found, layout: false }
+      format.html { render 'errors/not_found', status: :not_found, layout: 'error' }
       format.json { render json: { error: 'Not Found' }, status: :not_found }
     end
   end
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
     
     begin
       respond_to do |format|
-        format.html { render 'errors/internal_server_error', status: :internal_server_error, layout: false }
+        format.html { render 'errors/internal_server_error', status: :internal_server_error, layout: 'error' }
         format.json { render json: { error: 'Internal Server Error' }, status: :internal_server_error }
       end
     rescue => e
@@ -75,7 +75,7 @@ class ApplicationController < ActionController::Base
     
     begin
       respond_to do |format|
-        format.html { render 'errors/service_unavailable_error', status: :service_unavailable, layout: false }
+        format.html { render 'errors/service_unavailable_error', status: :service_unavailable, layout: 'error' }
         format.json { render json: { error: 'Service Unavailable' }, status: :service_unavailable }
       end
     rescue => e

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,4 @@
-class SearchTimeoutError < StandardError; end
+# class SearchTimeoutError < StandardError; end
 
 class ItemsController < ApplicationController
   include ActiveFiltersHelper
@@ -56,18 +56,18 @@ class ItemsController < ApplicationController
     respond_to do |format|
       format.html { render :search_result }
     end
-  rescue SearchTimeoutError
-    respond_to do |format|
-      format.html { render plain: "Search is taking too long. Please try with fewer filters.", status: 504 }
-      format.json { render json: { error: "Search is taking too long. Please try with fewer filters." }, status: 504 }
-    end
-  rescue => e
-    Rails.logger.error "******************************* Search error: #{e.message}"
-    Rails.logger.error e.backtrace.join("\n")
-    respond_to do |format|
-      format.html { render plain: "An error occurred during search", status: 500 }
-      format.json { render json: { error: "An error occurred during search" }, status: 500 }
-    end
+  # rescue SearchTimeoutError
+  #   respond_to do |format|
+  #     format.html { render plain: "Search is taking too long. Please try with fewer filters.", status: 504 }
+  #     format.json { render json: { error: "Search is taking too long. Please try with fewer filters." }, status: 504 }
+  #   end
+  # rescue => e
+  #   Rails.logger.error "******************************* Search error: #{e.message}"
+  #   Rails.logger.error e.backtrace.join("\n")
+  #   respond_to do |format|
+  #     format.html { render plain: "An error occurred during search", status: 500 }
+  #     format.json { render json: { error: "An error occurred during search" }, status: 500 }
+  #   end
   end
 
   def save_search
@@ -274,7 +274,7 @@ class ItemsController < ApplicationController
       ActiveRecord::Base.transaction do
         # Set the current timeout setting
         # Reset to original timeout (SET LOCAL is automatically reset at transaction end)        
-        begin
+        # begin
           ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = '10s'")
           cache_key = "filters_#{collection_ids.sort.join('_')}"
           filter_data = Rails.cache.fetch(cache_key, expires_in: 1.hour) do
@@ -284,10 +284,10 @@ class ItemsController < ApplicationController
           @continents, @countries, @states, @sexs = filter_data[:geo]
           @kingdoms, @phylums, @classes, @orders, @families, @genuses = filter_data[:taxonomy]
           @prep_types = filter_data[:prep_types]
-        rescue ActiveRecord::QueryCanceled
-          Rails.logger.error "******************************* Search timeout - filter data took too long"
-          raise SearchTimeoutError, "Filter data query timed out"
-        end
+        # rescue ActiveRecord::QueryCanceled
+        #   Rails.logger.error "******************************* Search timeout - filter data took too long"
+        #   raise SearchTimeoutError, "Filter data query timed out"
+        # end
       end
     end
 
@@ -454,9 +454,9 @@ class ItemsController < ApplicationController
         field_value: field_value.to_s,
         search_session_id: search_session_id
       )
-    rescue => e
-      Rails.logger.error "Failed to save search statistic: #{e.message}"
-      Rails.logger.error "Field: #{field_name}, Label: #{field_label}, Value: #{field_value}, Session: #{search_session_id}"
+    # rescue => e
+    #   Rails.logger.error "Failed to save search statistic: #{e.message}"
+    #   Rails.logger.error "Field: #{field_name}, Label: #{field_label}, Value: #{field_value}, Session: #{search_session_id}"
     end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,9 +16,6 @@ class ItemsController < ApplicationController
   end
 
   def search
-    if (Rails.env.development?) && params[:force_timeout] == "1"
-      raise ActiveRecord::QueryCanceled, "Manual timeout test"
-    end
     Rails.logger.info "++++++++++++++++++++++++++++++ In ItemsController#search"
 
     @view = params[:switch_view]&.in?(['rows', 'cards']) ? params[:switch_view] : 'rows'

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -434,10 +434,15 @@ class ItemsController < ApplicationController
       field_label = field_label.split('_').first.titleize
       SearchStatistic.create(
         field_name: field_name.to_s,
-        field_label: field_label.to_s, 
+        field_label: field_label.to_s,
         field_value: field_value.to_s,
         search_session_id: search_session_id
       )
+    rescue ActiveRecord::QueryCanceled, ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid => e
+      Rails.logger.warn "************************* Search statistic write failed: #{e.class} - #{e.message}"
+    rescue => e
+      Rails.logger.error "************************* Unexpected stats error: #{e.class} - #{e.message}"
+      raise if Rails.env.development?
     end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,6 +16,9 @@ class ItemsController < ApplicationController
   end
 
   def search
+    if (Rails.env.development?) && params[:force_timeout] == "1"
+      raise ActiveRecord::QueryCanceled, "Manual timeout test"
+    end
     Rails.logger.info "++++++++++++++++++++++++++++++ In ItemsController#search"
 
     @view = params[:switch_view]&.in?(['rows', 'cards']) ? params[:switch_view] : 'rows'
@@ -260,16 +263,15 @@ class ItemsController < ApplicationController
       ActiveRecord::Base.transaction do
         # Set the current timeout setting
         # Reset to original timeout (SET LOCAL is automatically reset at transaction end)        
-        # begin
-          ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = '10s'")
-          cache_key = "filters_#{collection_ids.sort.join('_')}"
-          filter_data = Rails.cache.fetch(cache_key, expires_in: 1.hour) do
-            build_filter_data(collection_ids)
-          end
-          
-          @continents, @countries, @states, @sexs = filter_data[:geo]
-          @kingdoms, @phylums, @classes, @orders, @families, @genuses = filter_data[:taxonomy]
-          @prep_types = filter_data[:prep_types]
+        ActiveRecord::Base.connection.execute("SET LOCAL statement_timeout = '10s'")
+        cache_key = "filters_#{collection_ids.sort.join('_')}"
+        filter_data = Rails.cache.fetch(cache_key, expires_in: 1.hour) do
+          build_filter_data(collection_ids)
+        end
+        
+        @continents, @countries, @states, @sexs = filter_data[:geo]
+        @kingdoms, @phylums, @classes, @orders, @families, @genuses = filter_data[:taxonomy]
+        @prep_types = filter_data[:prep_types]
       end
     end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,3 @@
-# class SearchTimeoutError < StandardError; end
-
 class ItemsController < ApplicationController
   include ActiveFiltersHelper
   skip_before_action :authenticate_user!, only: [ :show, :search, :quick_search, :export_to_csv ]
@@ -56,18 +54,6 @@ class ItemsController < ApplicationController
     respond_to do |format|
       format.html { render :search_result }
     end
-  # rescue SearchTimeoutError
-  #   respond_to do |format|
-  #     format.html { render plain: "Search is taking too long. Please try with fewer filters.", status: 504 }
-  #     format.json { render json: { error: "Search is taking too long. Please try with fewer filters." }, status: 504 }
-  #   end
-  # rescue => e
-  #   Rails.logger.error "******************************* Search error: #{e.message}"
-  #   Rails.logger.error e.backtrace.join("\n")
-  #   respond_to do |format|
-  #     format.html { render plain: "An error occurred during search", status: 500 }
-  #     format.json { render json: { error: "An error occurred during search" }, status: 500 }
-  #   end
   end
 
   def save_search
@@ -284,10 +270,6 @@ class ItemsController < ApplicationController
           @continents, @countries, @states, @sexs = filter_data[:geo]
           @kingdoms, @phylums, @classes, @orders, @families, @genuses = filter_data[:taxonomy]
           @prep_types = filter_data[:prep_types]
-        # rescue ActiveRecord::QueryCanceled
-        #   Rails.logger.error "******************************* Search timeout - filter data took too long"
-        #   raise SearchTimeoutError, "Filter data query timed out"
-        # end
       end
     end
 
@@ -454,9 +436,6 @@ class ItemsController < ApplicationController
         field_value: field_value.to_s,
         search_session_id: search_session_id
       )
-    # rescue => e
-    #   Rails.logger.error "Failed to save search statistic: #{e.message}"
-    #   Rails.logger.error "Field: #{field_name}, Label: #{field_label}, Value: #{field_value}, Session: #{search_session_id}"
     end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
         load_cached_filter_data(collection_ids)
       else
         Rails.logger.info "******************************* Filter data cache missing, rebuilding"
-        filter_data = setup_filter_data(collection_ids)
+        setup_filter_data(collection_ids)
         Rails.cache.write(filter_cache_key, filter_data, expires_in: 1.hour)
       end
     end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,22 +1,12 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in app/views/errors/internal_server_error.html.erb -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
-    </div>
-    <p>Try using navigation to get back on track<br>
-      
-      or go to the <a href="/" class="link_to">homepage</a>
-      
-      or <a id="myCustomTrigger" class="link_to" href="#" data-email="<%= session[:user_email]%>">Report an Issue</a>
-      </p>
+<!-- This file lives in app/views/errors/internal_server_error.html.erb -->
+<div class="dialog">
+  <div>
+    <h1>We're sorry, but something went wrong.</h1>
   </div>
-</body>
-</html>
+  <p>Try using navigation to get back on track<br>
+    
+    or go to the <a href="/" class="link_to">homepage</a>
+    
+    or <a id="myCustomTrigger" class="link_to" href="#" data-email="<%= session[:user_email]%>">Report an Issue</a>
+    </p>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,22 +1,12 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-</head>
-
-  <body class="rails-default-error-page">
-    <!-- This file lives in app/views/errors/not_found.html.erb -->
-    <div class="dialog">
-      <div>
-        <h1>The page you were looking for doesn't exist.</h1>
-        <p>You may have mistyped the address or the page may have moved.</p>
-      </div>
-      <p>Try using navigation to get back on track<br>
-      
-      or go to the <a href="/" class="link_to">homepage</a>
-      
-      or <a id="myCustomTrigger" class="link_to" href="#" data-email="<%= session[:user_email]%>">Report an Issue</a></p>
-    </div>
-  </body>
-</html>
+<!-- This file lives in app/views/errors/not_found.html.erb -->
+<div class="dialog">
+  <div>
+    <h1>The page you were looking for doesn't exist.</h1>
+    <p>You may have mistyped the address or the page may have moved.</p>
+  </div>
+  <p>Try using navigation to get back on track<br>
+  
+  or go to the <a href="/" class="link_to">homepage</a>
+  
+  or <a id="myCustomTrigger" class="link_to" href="#" data-email="<%= session[:user_email]%>">Report an Issue</a></p>
+</div>

--- a/app/views/errors/service_unavailable_error.html.erb
+++ b/app/views/errors/service_unavailable_error.html.erb
@@ -1,7 +1,7 @@
 <!-- This file lives in app/views/errors/service_unavailable_error.html.erb -->
 <div class="dialog">
   <div>
-    <h1>We're sorry, but something went wrong: Service Unavailable - Search timeout</h1>
+    <h1>We're sorry, but something went wrong: Service Unavailable - Request timeout</h1>
   </div>
   <p>Try using navigation to get back on track<br>
     

--- a/app/views/errors/service_unavailable_error.html.erb
+++ b/app/views/errors/service_unavailable_error.html.erb
@@ -1,22 +1,12 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>We're sorry, but something went wrong (503)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-</head>
-
-<body class="rails-default-error-page">
-  <!-- This file lives in app/views/errors/service_unavailable_error.html.erb -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong: Service Unavailable - Search timeout</h1>
-    </div>
-    <p>Try using navigation to get back on track<br>
-      
-      or go to the <a href="/" class="link_to">homepage</a>
-      
-      or <a id="myCustomTrigger" class="link_to" href="#" data-email="<%= session[:user_email]%>">Report an Issue</a>
-      </p>
+<!-- This file lives in app/views/errors/service_unavailable_error.html.erb -->
+<div class="dialog">
+  <div>
+    <h1>We're sorry, but something went wrong: Service Unavailable - Search timeout</h1>
   </div>
-</body>
-</html>
+  <p>Try using navigation to get back on track<br>
+    
+    or go to the <a href="/" class="link_to">homepage</a>
+    
+    or <a id="myCustomTrigger" class="link_to" href="#" data-email="<%= session[:user_email]%>">Report an Issue</a>
+    </p>
+</div>

--- a/app/views/errors/service_unavailable_error.html.erb
+++ b/app/views/errors/service_unavailable_error.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>We're sorry, but something went wrong (503)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+</head>
+
+<body class="rails-default-error-page">
+  <!-- This file lives in app/views/errors/service_unavailable_error.html.erb -->
+  <div class="dialog">
+    <div>
+      <h1>We're sorry, but something went wrong: Service Unavailable - Search timeout</h1>
+    </div>
+    <p>Try using navigation to get back on track<br>
+      
+      or go to the <a href="/" class="link_to">homepage</a>
+      
+      or <a id="myCustomTrigger" class="link_to" href="#" data-email="<%= session[:user_email]%>">Report an Issue</a>
+      </p>
+  </div>
+</body>
+</html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>BiorepositoryPortal</title>
+    <title>Lsa Biorepository</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <% unless Rails.env.production? %>
       <meta name="robots" content="noindex">

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>LSA RideShare</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <style>
+    .rails-default-error-page {
+      background-color: #EFEFEF;
+      color: #2E2F30;
+      text-align: center;
+      font-family: arial, sans-serif;
+      margin: 0;
+    }
+
+    .rails-default-error-page div.dialog {
+      width: 95%;
+      max-width: 33em;
+      margin: 4em auto 0;
+    }
+
+    .rails-default-error-page div.dialog > div {
+      border: 1px solid #CCC;
+      border-right-color: #999;
+      border-left-color: #999;
+      border-bottom-color: #BBB;
+      border-top: #B00100 solid 4px;
+      border-top-left-radius: 9px;
+      border-top-right-radius: 9px;
+      background-color: white;
+      padding: 7px 12% 0;
+      box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    }
+
+    .rails-default-error-page h1 {
+      font-size: 100%;
+      color: #730E15;
+      line-height: 1.5em;
+    }
+
+    .rails-default-error-page div.dialog > p {
+      margin: 0 0 1em;
+      padding: 1em;
+      background-color: #F7F7F7;
+      border: 1px solid #CCC;
+      border-right-color: #999;
+      border-left-color: #999;
+      border-bottom-color: #999;
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+      border-top-color: #DADADA;
+      color: #666;
+      box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+    }
+    </style>
+  </head>
+
+  <body class="rails-default-error-page">
+    <%= yield %>
+    <script type="text/javascript" src="https://umlsait.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/1kwsvv/b/8/c95134bc67d3a521bb3f4331beb9b804/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=54564fa1"></script>
+    <%= javascript_include_tag 'feedback', async: true %>
+  </body>
+</html>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>LSA RideShare</title>
+    <title>LSA Biorepository</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <style>
     .rails-default-error-page {

--- a/spec/requests/items_controller_spec.rb
+++ b/spec/requests/items_controller_spec.rb
@@ -71,6 +71,28 @@ RSpec.describe ItemsController, type: :request do
   end
 
   describe 'GET/POST /items/search' do
+    context 'when a query times out' do
+      before do
+        allow_any_instance_of(ItemsController)
+          .to receive(:setup_filter_data)
+          .and_raise(ActiveRecord::QueryCanceled, 'statement timeout')
+      end
+
+      it 'returns 503 for html requests' do
+        get search_items_path
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.body).to include('Service Unavailable')
+      end
+
+      it 'returns 503 for json requests' do
+        get search_items_path, params: {}, as: :json
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.parsed_body).to eq({ 'error' => 'Service Unavailable' })
+      end
+    end
+
     context 'with view switching' do
       it 'sets view to rows when switch_view is rows' do
         get search_items_path, params: { switch_view: 'rows' }

--- a/spec/requests/items_controller_spec.rb
+++ b/spec/requests/items_controller_spec.rb
@@ -71,10 +71,32 @@ RSpec.describe ItemsController, type: :request do
   end
 
   describe 'GET/POST /items/search' do
-    context 'when a query times out' do
+    context 'when a query for setup_filter_data times out' do
       before do
         allow_any_instance_of(ItemsController)
           .to receive(:setup_filter_data)
+          .and_raise(ActiveRecord::QueryCanceled, 'statement timeout')
+      end
+
+      it 'returns 503 for html requests' do
+        get search_items_path
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.body).to include('Service Unavailable')
+      end
+
+      it 'returns 503 for json requests' do
+        get search_items_path, params: {}, as: :json
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.parsed_body).to eq({ 'error' => 'Service Unavailable' })
+      end
+    end
+
+    context 'when a query for execute_search_and_paginate times out' do
+      before do
+        allow_any_instance_of(ItemsController)
+          .to receive(:execute_search_and_paginate)
           .and_raise(ActiveRecord::QueryCanceled, 'statement timeout')
       end
 


### PR DESCRIPTION
Please see the description in the pull request overview below. 
To test run specific tests:
```
rspec spec/requests/items_controller_spec.rb:74
rspec spec/requests/items_controller_spec.rb:96
```
Also, I did the following tests:
To the items_controller, after line 19, I added 
```
  if (Rails.env.development?) && params[:force_timeout] == "1"
    raise ActiveRecord::QueryCanceled, "Manual timeout test"
  end
```
then commented lines 4 and 8 in the application controller and called the search directly:
http://localhost:3000/items/search?force_timeout=1


