### PR TITLE
Refactor default search query construction, add DB index on items' catalog_number

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -329,11 +329,24 @@ class ItemsController < ApplicationController
         transform_search_groupings unless params[:page].present?
         @quick_search_filters = false
         
-        @q = Item.left_outer_joins(:current_identification, :collection)
-                .select('items.*, identifications.scientific_name, collections.division')
-                .order(@sort)
-                .ransack(params[:q])
+        # Keeps the common catalog-number path minimal and fast, 
+        # while adding the identification join only when scientific-name sorting requires it.
+        @q = search_scope.ransack(params[:q])
       end
+    end
+
+    def search_scope
+      scope = Item.all
+
+      # PostgreSQL requires a DISTINCT query's ordered joined column to appear
+      # in its SELECT list. Avoid this join for the much more common item sort.
+      if @sort.start_with?('identifications.')
+        scope = scope
+          .left_outer_joins(:current_identification)
+          .select('items.*, identifications.scientific_name')
+      end
+
+      scope.order(@sort)
     end
     
     # Sanitize sort parameters to prevent SQL injection

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -45,7 +45,8 @@
 #
 # Indexes
 #
-#  index_items_on_collection_id  (collection_id)
+#  index_items_on_catalog_number  (catalog_number)
+#  index_items_on_collection_id   (collection_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20260602110330_add_index_to_items_catalog_number.rb
+++ b/db/migrate/20260602110330_add_index_to_items_catalog_number.rb
@@ -1,0 +1,7 @@
+class AddIndexToItemsCatalogNumber < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :items, :catalog_number, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_20_172522) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_02_110330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -238,6 +238,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_20_172522) do
     t.string "verbatim_event_date"
     t.string "verbatim_locality"
     t.string "vitality"
+    t.index ["catalog_number"], name: "index_items_on_catalog_number"
     t.index ["collection_id"], name: "index_items_on_collection_id"
   end
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -45,7 +45,8 @@
 #
 # Indexes
 #
-#  index_items_on_collection_id  (collection_id)
+#  index_items_on_catalog_number  (catalog_number)
+#  index_items_on_collection_id   (collection_id)
 #
 # Foreign Keys
 #

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -45,7 +45,8 @@
 #
 # Indexes
 #
-#  index_items_on_collection_id  (collection_id)
+#  index_items_on_catalog_number  (catalog_number)
+#  index_items_on_collection_id   (collection_id)
 #
 # Foreign Keys
 #

--- a/spec/requests/items_controller_spec.rb
+++ b/spec/requests/items_controller_spec.rb
@@ -134,6 +134,34 @@ RSpec.describe ItemsController, type: :request do
     end
   end
 
+  describe 'search query joins' do
+    it 'does not join associations for the default catalog number sort' do
+      queries = capture_sql do
+        get search_items_path
+      end
+
+      page_query = queries.find { |sql| sql.include?('ORDER BY items.catalog_number asc LIMIT') }
+
+      expect(response).to have_http_status(:ok)
+      expect(page_query).to be_present
+      expect(page_query).not_to include('JOIN "identifications"')
+      expect(page_query).not_to include('JOIN "collections"')
+    end
+
+    it 'joins current identifications when sorting by scientific name' do
+      queries = capture_sql do
+        get search_items_path, params: { sort: 'identifications.scientific_name asc' }
+      end
+
+      page_query = queries.find { |sql| sql.include?('ORDER BY identifications.scientific_name asc LIMIT') }
+
+      expect(response).to have_http_status(:ok)
+      expect(page_query).to be_present
+      expect(page_query).to include('JOIN "identifications"')
+      expect(page_query).not_to include('JOIN "collections"')
+    end
+  end
+
   describe 'GET /export_to_csv' do
     context 'when authenticated' do
       before { mock_login(user) }
@@ -238,6 +266,16 @@ RSpec.describe ItemsController, type: :request do
       # 3. The out-of-scope collection data is completely ignored
       expect(response.body).not_to include('Mordor')
     end
+  end
+
+  def capture_sql(&block)
+    queries = []
+    callback = lambda do |_name, _start, _finish, _id, payload|
+      queries << payload[:sql] unless payload[:name] == 'SCHEMA'
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+    queries
   end
 
 end


### PR DESCRIPTION
Optimizes the advanced-search page's default load-times by removing unnecessary association joins from the default query and adding an index on items.catalog_number.

Previously, searches always joined identifications and collections, selected associated columns, deduplicated the joined result set, and sorted by catalog number before returning the first 25 records. At approximately one million items, the page query alone took roughly 1.4-1.5 seconds.

The refactored query starts from Item.all. Association joins are now introduced only when required by a filter or sort. Scientific-name sorting remains supported through an explicit current-identification join.

**Database Change**
Adds a concurrent PostgreSQL index:

```bash
add_index :items, :catalog_number, algorithm: :concurrently
```

This allows PostgreSQL to retrieve the first catalog-number-sorted page directly through an index scan.

**Performance Impact**

The primary page query improved from approximately 1.4-1.5 seconds to approximately 0.4s.

```bash
Index Scan using index_items_on_catalog_number on items
```

Complete advanced-search cache-hit requests dropped to approximately 222-258 ms.

**Testing**

Added RSpecs verifying that:

- Default catalog-number sorting does not join identifications.
- Default catalog-number sorting does not join collections.
- Scientific-name sorting still joins current identifications.
- Scientific-name sorting does not add an unnecessary collections join.