### PR TITLE
Optimize advanced search pagination counts

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -364,13 +364,18 @@ class ItemsController < ApplicationController
       # Get base results
       filtered_items = @q.result.distinct
       
-      # Count only distinct item IDs to avoid PostgreSQL error
-      @total_items = @q.result.distinct.count('items.id')
-      collection_ids = @q.result.distinct.reorder('').pluck('items.collection_id')
+      # Count only distinct item IDs to avoid PostgreSQL count inflation from joins
+      @total_items = filtered_items.count('items.id')
+      collection_ids = filtered_items.reorder('').pluck('items.collection_id')
       @collections = Collection.where(id: collection_ids).pluck(:division).uniq.join(', ')
       
       # Paginated items with includes for efficiency
       @items = filtered_items.includes(:collection, :current_identification, :preparations).page(params[:page]).per(params[:per].presence || Kaminari.config.default_per_page)
+
+      # Kaminari's view helpers call @items.total_count during rendering.
+      # Override it on this relation only so they reuse the count above.
+      total_items = @total_items
+      @items.define_singleton_method(:total_count) { total_items }
 
       @all_collections = Collection.order(:division)
     end

--- a/spec/requests/items_controller_spec.rb
+++ b/spec/requests/items_controller_spec.rb
@@ -132,6 +132,17 @@ RSpec.describe ItemsController, type: :request do
       get search_items_path, params: { per: 25 }
       expect(response).to have_http_status(:ok)
     end
+
+    it 'reuses one exact item count for the result summary and numbered pagination' do
+      FactoryBot.create_list(:item, 25, collection: collection)
+
+      queries = capture_sql do
+        get search_items_path, params: { per: 25 }
+      end
+
+      expect(response).to have_http_status(:ok)
+      expect(item_count_queries(queries).length).to eq(1)
+    end
   end
 
   describe 'GET /export_to_csv' do
@@ -238,6 +249,20 @@ RSpec.describe ItemsController, type: :request do
       # 3. The out-of-scope collection data is completely ignored
       expect(response.body).not_to include('Mordor')
     end
+  end
+
+  def capture_sql(&block)
+    queries = []
+    callback = lambda do |_name, _start, _finish, _id, payload|
+      queries << payload[:sql] unless payload[:name] == 'SCHEMA'
+    end
+
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+    queries
+  end
+
+  def item_count_queries(queries)
+    queries.grep(/COUNT\(DISTINCT "?items"?\."?id"?\)/)
   end
 
 end


### PR DESCRIPTION
## Summary

Optimizes `ItemsController#execute_search_and_paginate` by reusing the already-built filtered search relation and avoiding duplicate exact count queries during result rendering.

## Changes

- Reuse `filtered_items` for both the exact item count and collection-id lookup.
- Compute `COUNT(DISTINCT items.id)` once.
- Override `total_count` on the paginated `@items` relation so Kaminari’s `page_entries_info` and `paginate` helpers reuse the existing count instead of initiating another count query.
- Add an RSpec to verify that the advanced-search render path performs only one exact item count query.

## Why

The advanced-search page already computed an exact result count in the controller, but Kaminari helpers triggered additional count queries during view rendering. This produced avoidable database work on every search request.

## Testing

```text
bundle exec rspec spec/requests/items_controller_spec.rb -e 'reuses one exact item count'