### PR TITLE
Refactor global checkout initialization to reduce unnecessary database hits

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :set_render_checkout
   before_action :initialize_checkout, unless: :skip_checkout_initialization?
+  before_action :set_checkout_active_count, unless: :skip_checkout_initialization?
   around_action :prosopite_scan, if: -> { Rails.env.development? && defined?(Prosopite) }
 
   before_action :make_q
@@ -125,11 +126,9 @@ end
   end
 
   def initialize_checkout
-    requestables_includes = { requestables: [:preparation, { item: [:collection, :preparations, :current_identification] }] }
-
     # Only query database if we don't have a checkout ID in session
     if session[:checkout_id].present?
-      @checkout = Checkout.includes(requestables_includes).find_by(id: session[:checkout_id]) unless @checkout
+      @checkout = Checkout.find_by(id: session[:checkout_id]) unless @checkout
     end
 
     # Create checkout only if we still don't have one
@@ -141,13 +140,13 @@ end
     # Handle user assignment efficiently
     if user_signed_in?
       # Look up any existing checkout for the current user
-      user_checkout = Checkout.includes(requestables_includes).find_by(user_id: current_user.id)
+      user_checkout = Checkout.find_by(user_id: current_user.id)
       
       if user_checkout.present?
         Rails.logger.info "************************************ session[:merge_checkouts]: #{session[:merge_checkouts]}"
         Rails.logger.info "************************************ User has existing checkout with ID: #{user_checkout.id}"
-        if session[:merge_checkouts] && @checkout.id != current_user.checkout.id
-          merge_checkouts(@checkout, current_user.checkout)
+        if session[:merge_checkouts] && @checkout.id != user_checkout.id
+          merge_checkouts(@checkout, user_checkout)
           session.delete(:merge_checkouts)
           # Reload user_checkout to reflect merged requestables
           user_checkout.requestables.reload
@@ -159,6 +158,10 @@ end
         @checkout.update(user_id: current_user.id)
       end
     end
+  end
+
+  def set_checkout_active_count
+    @checkout_active_count = @checkout&.requestables&.active&.count.to_i
   end
 
   def checkout_availability
@@ -194,6 +197,7 @@ end
         end
       end
     end
+    set_checkout_active_count
     alert
   end
 
@@ -254,4 +258,3 @@ end
   
 
 end
-

--- a/app/controllers/checkout_controller.rb
+++ b/app/controllers/checkout_controller.rb
@@ -15,6 +15,7 @@ class CheckoutController < ApplicationController
 
       # Reload the checkout to ensure the new requestable is included in the association
       @checkout.requestables.reload
+      set_checkout_active_count
 
     respond_to do |format|
       format.turbo_stream do
@@ -62,6 +63,7 @@ class CheckoutController < ApplicationController
 
     # Reload the checkout to ensure the updated requestable is included in the association
     @checkout.requestables.reload
+    set_checkout_active_count
 
     respond_to do |format|
       format.turbo_stream do
@@ -81,6 +83,7 @@ class CheckoutController < ApplicationController
     authorize @checkout if current_user
     Requestable.find(params[:id])&.destroy
     @checkout.requestables.reload # Reload the association to reflect the destroyed record
+    set_checkout_active_count
     flash.now[:notice] = "Preparation removed from checkout."
     respond_to do |format|
       format.turbo_stream do
@@ -104,6 +107,7 @@ class CheckoutController < ApplicationController
       flash.now[:alert] = "No matching preparation found in checkout."
     end
     @checkout.requestables.reload # Reload the association to reflect the destroyed record
+    set_checkout_active_count
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: [
@@ -139,6 +143,7 @@ class CheckoutController < ApplicationController
       flash.now[:alert] = "Preparation not found in checkout."
     end
     @checkout.requestables.reload # Reload the association to reflect the updated record
+    set_checkout_active_count
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: [turbo_stream.replace('checkout',
@@ -161,6 +166,7 @@ class CheckoutController < ApplicationController
       flash.now[:alert] = "Preparation not found in saved for later."
     end
     @checkout.requestables.reload # Reload the association to reflect the updated record
+    set_checkout_active_count
     respond_to do |format|
       format.turbo_stream do
         render turbo_stream: [turbo_stream.replace('checkout',

--- a/app/views/checkout/_total.html.erb
+++ b/app/views/checkout/_total.html.erb
@@ -1,4 +1,4 @@
-<% active_count = @checkout.requestables.count(&:active?) %>
+<% active_count = @checkout_active_count.to_i %>
 
 <% if active_count > 0 %>
     (<%= active_count %>)


### PR DESCRIPTION
This refactors the global checkout setup so every page can still show the checkout item count without eager-loading the full checkout object graph on every request.

ApplicationController#initialize_checkout runs before most controller actions. Previously, that method loaded checkout requestables plus nested preparation/item/collection/current-identification data even when the page only needed the navbar checkout count.

This change keeps checkout initialization lightweight and moves the navbar count into a separate controller-provided value.

**Changes**

- Remove heavy Checkout.includes(...) from global checkout initialization.
- Add set_checkout_active_count to calculate the active checkout count separately.
- Update checkout/_total to render from @checkout_active_count, making the partial nil-safe.
- Refresh @checkout_active_count after checkout mutations so Turbo Frame count updates stay accurate.
- Avoid an extra checkout lookup during checkout merge by reusing the already-loaded user_checkout.

**Why**

Most pages need a checkout record and an active-item count, not the full checkout details (such as preparations, requestables, etc.)
Detailed checkout association loading should happen only on pages/actions that actually need those records.
This reduces unnecessary database work in the shared request path while preserving existing user-visible behavior.

**Unchanged behavior**

- The checkout count still appears in the navbar Turbo Frame.
- Checkout records are still created when needed.
- Signed-in users are still associated with their checkout.
- Checkout merge behavior is preserved.
- Checkout Turbo Stream updates still refresh the count immediately.