### PR TITLE
Make checkout count reflect available preparations and checked-out items.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -161,7 +161,7 @@ end
   end
 
   def set_checkout_active_count
-    @checkout_active_count = @checkout&.requestables&.active&.count.to_i
+    @checkout_active_count = @checkout&.requestables&.available_for_checkout&.count.to_i
   end
 
   def checkout_availability

--- a/app/models/requestable.rb
+++ b/app/models/requestable.rb
@@ -33,11 +33,12 @@ class Requestable < ApplicationRecord
 
   scope :saved_for_later, -> { where(saved_for_later: true) }
   scope :active, -> { where(saved_for_later: false).where.not(preparation_id: nil).where.not(item_id: nil) }
+  scope :available_for_checkout, -> { active.joins(:preparation).where("preparations.count > 0") }
 
-def active?
-  return false if saved_for_later
+  def active?
+    return false if saved_for_later
 
-  preparation_id.present? && item_id.present?
-end
+    preparation_id.present? && item_id.present?
+  end
 
 end

--- a/spec/models/requestable_spec.rb
+++ b/spec/models/requestable_spec.rb
@@ -29,5 +29,50 @@
 require 'rails_helper'
 
 RSpec.describe Requestable, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.available_for_checkout' do
+    let(:collection) { FactoryBot.create(:collection) }
+    let(:item) { FactoryBot.create(:item, collection: collection) }
+    let(:checkout) { FactoryBot.create(:checkout) }
+
+    it 'includes active requestables with available preparations' do
+      preparation = FactoryBot.create(:preparation, item: item, count: 2)
+      requestable = FactoryBot.create(:requestable, checkout: checkout, preparation: preparation, item_id: item.id)
+
+      expect(described_class.available_for_checkout).to include(requestable)
+    end
+
+    it 'excludes active requestables when the preparation is no longer available' do
+      preparation = FactoryBot.create(:preparation, item: item, count: 0)
+      requestable = FactoryBot.create(:requestable, checkout: checkout, preparation: preparation, item_id: item.id)
+
+      expect(described_class.available_for_checkout).not_to include(requestable)
+    end
+
+    it 'excludes requestables saved for later' do
+      preparation = FactoryBot.create(:preparation, item: item, count: 2)
+      requestable = FactoryBot.create(:requestable, checkout: checkout, preparation: preparation, item_id: item.id, saved_for_later: true)
+
+      expect(described_class.available_for_checkout).not_to include(requestable)
+    end
+
+    it 'excludes requestables without item or preparation links' do
+      requestable = FactoryBot.create(:requestable, checkout: checkout)
+
+      expect(described_class.available_for_checkout).not_to include(requestable)
+    end
+
+    it 'stops counting another checkout requestable after inventory is consumed' do
+      other_checkout = FactoryBot.create(:checkout)
+      preparation = FactoryBot.create(:preparation, item: item, count: 1)
+
+      FactoryBot.create(:requestable, checkout: checkout, preparation: preparation, item_id: item.id)
+      other_requestable = FactoryBot.create(:requestable, checkout: other_checkout, preparation: preparation, item_id: item.id)
+
+      expect(other_checkout.requestables.available_for_checkout).to include(other_requestable)
+
+      preparation.update!(count: 0)
+
+      expect(other_checkout.requestables.available_for_checkout).not_to include(other_requestable)
+    end
+  end
 end

--- a/spec/requests/checkout_controller_spec.rb
+++ b/spec/requests/checkout_controller_spec.rb
@@ -104,6 +104,19 @@ RSpec.describe CheckoutController, type: :request do
       get checkout_path
       expect(response.body).to include("<option selected=\"selected\" value=\"3\">3</option>")
     end
+
+    it 'does not count checkout items whose preparation is no longer available' do
+      post checkout_add_path, params: { id: preparation.id, count: 1 }, headers: {'Accept' => 'text/vnd.turbo-stream.html'}
+      expect(response).to have_http_status(200)
+
+      get checkout_path
+      expect(response.body).to include("(1)")
+
+      preparation.update!(count: 0)
+
+      get checkout_path
+      expect(response.body).not_to include("(1)")
+    end
   end
 
 end


### PR DESCRIPTION
This updates the global checkout badge count so it only includes checkout items whose preparations are still available.
Previously, the navbar count used active requestables. A requestable could remain active even if another user had already checked out the same preparation and reduced its inventory to zero. In that case, the other user’s checkout badge could still show the stale item count until their checkout was revalidated.

This change adds an availability-aware requestable scope and uses it for the shared checkout count.

**Changes**
- Add Requestable.available_for_checkout.
- Count only active requestables joined to preparations with preparations.count > 0.
- Keep existing checkout cleanup behavior unchanged.
- Add model specs for available/unavailable/saved-for-later/missing-link requestables.
- Add request coverage showing the rendered checkout count drops after a preparation becomes unavailable.

**Behavior**
- If two users have the same preparation in checkout and one user checks it out, reducing inventory to zero, the other user’s badge count drops on their next page request.
- The stale requestable row is not globally deleted in the background.
- Existing checkout availability cleanup still handles moving/removing stale checkout items when the user visits checkout or continues the loan request flow.

**Verification**
```bash
ruby -c app/models/requestable.rb
ruby -c app/controllers/application_controller.rb
ruby -c spec/models/requestable_spec.rb
ruby -c spec/requests/checkout_controller_spec.rb
bundle exec rspec spec/models/requestable_spec.rb spec/requests/checkout_controller_spec.rb
Focused specs pass: 16 examples, 0 failures.
```