### PR TITLE
Fix ProfilesController#show n+1

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,7 +5,13 @@ class ProfilesController < ApplicationController
 
   def show
     @collections = Collection.joins(:collection_questions).distinct
-    @loan_requests = current_user.loan_requests.with_attached_pdf_file.with_attached_csv_file.order(created_at: :desc)
+    @loan_requests = current_user.loan_requests
+                                 .includes(
+                                   pdf_file_attachment: :blob,
+                                   csv_file_attachment: :blob,
+                                   attachment_files_attachments: :blob
+                                 )
+                                 .order(created_at: :desc)
     @information_requests = current_user.information_requests.order(created_at: :desc)
   end
 
@@ -104,7 +110,7 @@ class ProfilesController < ApplicationController
     end
 
     redirect_to show_collections_questions_profile_path, notice: "Loan questions updated successfully."
-  end    
+  end
 
   def show_collections_questions
     @collections = Collection.joins(:collection_questions).distinct
@@ -121,8 +127,8 @@ class ProfilesController < ApplicationController
       @collection_answers[collection] = question_answer_hash
     end
     loan_questions = LoanQuestion.includes(:loan_answers).order(:position)
-	  @loan_answers = loan_questions.each_with_object({}) do |question, hash|
-	    hash[question] = question.loan_answers.find { |answer| answer.user_id == current_user.id }
+    @loan_answers = loan_questions.each_with_object({}) do |question, hash|
+      hash[question] = question.loan_answers.find { |answer| answer.user_id == current_user.id }
     end
   end
 
@@ -169,5 +175,5 @@ class ProfilesController < ApplicationController
   def profile_params
     params.require(:user).permit(:first_name, :last_name, :affiliation, :orcid)
   end
-  
+
 end

--- a/app/views/loan_requests/_submitted_requests.html.erb
+++ b/app/views/loan_requests/_submitted_requests.html.erb
@@ -19,14 +19,14 @@
           <td><%= request.send_to %></td>
           <td>
             <% if pdf_attachment.present? %>
-              <%= link_to 'View PDF', rails_blob_url(pdf_attachment, disposition: "inline"), target: "_blank", class: "btn btn-sm btn-outline-primary" %>
+              <%= link_to 'View PDF', rails_blob_url(pdf_attachment, disposition: "inline"), target: "_blank", rel: "noopener noreferrer",  class: "btn btn-sm btn-outline-primary" %>
             <% else %>
               <span class="text-muted">No PDF</span>
             <% end %>
           </td>
           <td>
             <% if csv_attachment.present? %>
-              <%= link_to 'Download CSV', rails_blob_url(csv_attachment, disposition: "attachment"), target: "_blank", class: "btn btn-sm btn-outline-primary" %>
+              <%= link_to 'Download CSV', rails_blob_url(csv_attachment, disposition: "attachment"), target: "_blank", rel: "noopener noreferrer", class: "btn btn-sm btn-outline-primary" %>
             <% else %>
               <span class="text-muted">No CSV</span>
             <% end %>

--- a/app/views/loan_requests/_submitted_requests.html.erb
+++ b/app/views/loan_requests/_submitted_requests.html.erb
@@ -11,25 +11,28 @@
     </thead>
     <tbody>
       <% @loan_requests.each do |request| %>
+        <% pdf_attachment = request.pdf_file_attachment %>
+        <% csv_attachment = request.csv_file_attachment %>
+        <% attachment_files = request.attachment_files_attachments %>
         <tr>
           <td><%= request.created_at.in_time_zone("Eastern Time (US & Canada)").strftime("%Y-%m-%d %H:%M") %></td>
           <td><%= request.send_to %></td>
           <td>
-            <% if request.pdf_file.attached? %>
-              <%= link_to 'View PDF', rails_blob_url(request.pdf_file, disposition: "inline"), target: "_blank", class: "btn btn-sm btn-outline-primary" %>
+            <% if pdf_attachment.present? %>
+              <%= link_to 'View PDF', rails_blob_url(pdf_attachment, disposition: "inline"), target: "_blank", class: "btn btn-sm btn-outline-primary" %>
             <% else %>
               <span class="text-muted">No PDF</span>
             <% end %>
           </td>
           <td>
-            <% if request.csv_file.attached? %>
-              <%= link_to 'Download CSV', rails_blob_url(request.csv_file, disposition: "attachment"), target: "_blank", class: "btn btn-sm btn-outline-primary" %>
+            <% if csv_attachment.present? %>
+              <%= link_to 'Download CSV', rails_blob_url(csv_attachment, disposition: "attachment"), target: "_blank", class: "btn btn-sm btn-outline-primary" %>
             <% else %>
               <span class="text-muted">No CSV</span>
             <% end %>
           </td>
           <td>
-            <% if request.attachment_files.attached? %>
+            <% if attachment_files.any? %>
               <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#attachmentsModal-<%= request.id %>" aria-label="Open attachments modal for request <%= request.id %>">
                 Attached Files
               </button>
@@ -44,7 +47,7 @@
                     </div>
                     <div class="modal-body">
                       <ul class="list-group">
-                        <% request.attachment_files.each do |file| %>
+                        <% attachment_files.each do |file| %>
                           <li class="list-group-item">
                             <%= link_to file.filename.to_s, rails_blob_url(file, disposition: "attachment"), target: "_blank", rel: "noopener noreferrer" %>
                           </li>


### PR DESCRIPTION
Fixes a Skylight-reported ActiveStorage N+1 in `ProfilesController#show`.

The profile page renders submitted loan requests and checks PDF, CSV, and additional file attachments for each request. Those per-row `attached?` checks were producing repeated `active_storage_attachments` queries. This became apparent when we began testing staging and our profiles each had multiple loan requests sent over time.

**Changes**

- Preload loan request attachment associations in `ProfilesController#show`.
- Include blobs because the view renders filenames and blob URLs.
- Update the submitted loan requests partial to use preloaded attachment associations directly instead of calling `attached?` inside the loop.