### PR TITLE
Resolve N+1 on loan and collection questio…

### DIFF
--- a/app/controllers/collections/collection_questions_controller.rb
+++ b/app/controllers/collections/collection_questions_controller.rb
@@ -144,3 +144,4 @@ class Collections::CollectionQuestionsController < ApplicationController
   end
     
 end
+

--- a/app/controllers/collections/collection_questions_controller.rb
+++ b/app/controllers/collections/collection_questions_controller.rb
@@ -78,7 +78,7 @@ class Collections::CollectionQuestionsController < ApplicationController
 
   def move_up
     @collection_question.move_higher
-    @collection_questions = @collection.collection_questions.order(:position)
+    @collection_questions = @collection.collection_questions.includes(:rich_text_question).order(:position)
     
     respond_to do |format|
       format.turbo_stream { 
@@ -93,7 +93,7 @@ class Collections::CollectionQuestionsController < ApplicationController
 
   def move_down
     @collection_question.move_lower
-    @collection_questions = @collection.collection_questions.order(:position)
+    @collection_questions = @collection.collection_questions.includes(:rich_text_question).order(:position)
     
     respond_to do |format|
       format.turbo_stream { 
@@ -110,7 +110,7 @@ class Collections::CollectionQuestionsController < ApplicationController
     @collection_question.destroy
 
     respond_to do |format|
-      @collection_questions = @collection.collection_questions.order(:position)
+      @collection_questions = @collection.collection_questions.includes(:rich_text_question).order(:position)
       format.turbo_stream
       format.html { redirect_to collection_path(@collection), notice: "Collection question deleted." }
     end

--- a/app/controllers/collections/collection_questions_controller.rb
+++ b/app/controllers/collections/collection_questions_controller.rb
@@ -24,11 +24,8 @@ class Collections::CollectionQuestionsController < ApplicationController
     respond_to do |format|
       begin
         if @collection_question.save
-          if collection_question_params[:question_type].in?(%w[dropdown checkbox])
-            options = params[:options_attributes].values
-            options.each do |option|
-              CollectionOption.create(value: option[:value], collection_question_id: @collection_question.id)
-            end
+          if @collection_question.question_type.in?(%w[dropdown checkbox]) && params[:options_attributes].present?
+            create_options(@collection_question, params[:options_attributes].values)
           end
           format.html { redirect_to collection_collection_question_path(@collection, @collection_question), notice: "Collection question created." }
           format.json { render :show, status: :ok, location: [@collection, @collection_question] }
@@ -120,8 +117,12 @@ class Collections::CollectionQuestionsController < ApplicationController
 
   def update_options(question, option_params)
     question.collection_options.destroy_all
+    create_options(question, option_params)
+  end
+
+  def create_options(question, option_params)
     option_params.each do |option|
-      CollectionOption.create(value: option[:value], collection_question_id: question.id)
+      question.collection_options.create!(value: option[:value])
     end
   end
 

--- a/app/controllers/loan_questions_controller.rb
+++ b/app/controllers/loan_questions_controller.rb
@@ -152,3 +152,4 @@ class LoanQuestionsController < ApplicationController
       params.require(:loan_question).permit(:position, :question, :question_type, :required, options_attributes: [:id, :value])
     end
 end
+

--- a/app/controllers/loan_questions_controller.rb
+++ b/app/controllers/loan_questions_controller.rb
@@ -82,7 +82,7 @@ class LoanQuestionsController < ApplicationController
   # DELETE /loan_questions/1 or /loan_questions/1.json
   def destroy
     if @loan_question.destroy
-      @loan_questions = LoanQuestion.all
+      @loan_questions = LoanQuestion.includes(:rich_text_question).order(:position)
       flash.now[:notice] = "Loan question was successfully deleted."
     end
   end
@@ -96,7 +96,7 @@ class LoanQuestionsController < ApplicationController
   def move_up
     @loan_question.move_higher
     authorize @loan_question
-    @loan_questions = LoanQuestion.order(:position)
+    @loan_questions = LoanQuestion.includes(:rich_text_question).order(:position)
     
     respond_to do |format|
       format.turbo_stream { 
@@ -112,7 +112,7 @@ class LoanQuestionsController < ApplicationController
   def move_down
     @loan_question.move_lower
     authorize @loan_question
-    @loan_questions = LoanQuestion.order(:position)
+    @loan_questions = LoanQuestion.includes(:rich_text_question).order(:position)
     
     respond_to do |format|
       format.turbo_stream { 
@@ -152,4 +152,3 @@ class LoanQuestionsController < ApplicationController
       params.require(:loan_question).permit(:position, :question, :question_type, :required, options_attributes: [:id, :value])
     end
 end
-

--- a/app/controllers/loan_questions_controller.rb
+++ b/app/controllers/loan_questions_controller.rb
@@ -29,19 +29,12 @@ class LoanQuestionsController < ApplicationController
   def create
     @loan_question = LoanQuestion.new(loan_question_params)
     authorize @loan_question
-    
-    if loan_question_params[:question_type] == "dropdown" || loan_question_params[:question_type] == "checkbox"
-      options = params[:options_attributes].values
-    end
 
     respond_to do |format|
       begin
         if @loan_question.save
-          if loan_question_params[:question_type] == "dropdown" || loan_question_params[:question_type] == "checkbox" 
-            options = params[:options_attributes].values        
-            options.each do |option|
-              Option.create(value: option[:value], loan_question_id: @loan_question.id)
-            end
+          if @loan_question.question_type.in?(%w[dropdown checkbox]) && params[:options_attributes].present?
+            create_options(@loan_question, params[:options_attributes].values)
           end
           format.html { redirect_to @loan_question, notice: "Loan question was successfully created." }
           format.json { render :show, status: :ok, location: @loan_question }
@@ -130,13 +123,18 @@ class LoanQuestionsController < ApplicationController
     def update_options(loan_question, options_attributes)
       if loan_question.options.present?
         Option.where(loan_question_id: loan_question.id).destroy_all
-        options_attributes.each do |option|
-          # raise ActiveRecord::Rollback unless 
-          Option.create(value: option[:value], loan_question_id: loan_question.id)
-        end
+        create_options(loan_question, options_attributes)
       end
       true
     end
+
+    def create_options(loan_question, options_attributes)
+      options_attributes.each do |option|
+        loan_question.options.create!(value: option[:value])
+      end
+      true
+    end
+
     # Use callbacks to share common setup or constraints between actions.
     def set_loan_question
       @loan_question = LoanQuestion.find(params[:id])


### PR DESCRIPTION
…n pages

- Add includes(:rich_text_question) to move_up, move_down, and destroy actions in LoanQuestionsController to prevent N+1 when Turbo Stream re-renders the list after reordering or deletion
- Add includes(:rich_text_question) to move_up, move_down, and destroy actions in Collections::CollectionQuestionsController for the same reason
- index and preview actions were already correctly eager loading