### PR TITLE
Hide empty collections from search sidebar and scope

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,6 @@ group :development, :staging, :phase2_staging do
   gem 'pghero', git: 'https://github.com/andyatkinson/pghero.git'
 end
 
-group :development, :phase2_staging do
+group :development, :test, :phase2_staging do
   gem 'faker'
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -235,7 +235,7 @@ class ItemsController < ApplicationController
         params[:q] = ActionController::Parameters.new("collection_id_in" => [collection_ids.first])
         collection_ids
       else
-        Collection.pluck(:id)
+        Collection.joins(:items).distinct.pluck(:id)
       end
 
       normalize_collection_ids(collection_ids)
@@ -362,7 +362,7 @@ class ItemsController < ApplicationController
       total_items = @total_items
       @items.define_singleton_method(:total_count) { total_items }
 
-      @all_collections = Collection.order(:division)
+      @all_collections = Collection.joins(:items).distinct.order(:division)
     end
     
     def setup_dynamic_fields


### PR DESCRIPTION
Only show collections with items in sidebar filter checkboxes and exclude empty collections from default search scope.

Changes:
- extract_collection_ids: Collection.joins(:items).distinct.pluck(:id) excludes empty collections from search scope by default
- execute_search_and_paginate: Collection.joins(:items).distinct.order(:division) hides empty collections from sidebar filter checkboxes

Why:
CZEUM has no items and was appearing in search sidebar causing user confusion — selecting it returned zero results.

Fix is generic — any empty collection is automatically hidden. When items are added to a collection it automatically appears. No manual intervention needed.

Verified locally:
- Empty collection hidden from search sidebar
- Collection appears automatically when first item added
- Collection disappears when last item removed
- Collection still visible on /collections catalog page
- 132 RSpec tests passing