### PR TITLE
Fix app preference N+1 in creation and view

### DIFF
--- a/app/controllers/app_preferences_controller.rb
+++ b/app/controllers/app_preferences_controller.rb
@@ -18,6 +18,7 @@ class AppPreferencesController < ApplicationController
       @collections = Collection.where(id: session[:collection_ids])
       @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
     end
+    @app_prefs_by_collection = @app_prefs.group_by(&:collection_id)
     @global_prefs = GlobalPreference.includes(:image_attachment).all.order(:pref_type, :description)
     authorize @app_prefs
     authorize @global_prefs
@@ -54,6 +55,7 @@ class AppPreferencesController < ApplicationController
               flash.now[:alert] = "Error updating app preference: #{app_pref&.errors&.full_messages&.join(', ') || 'Preference not found.'}"
               @collections = Collection.where(id: session[:collection_ids])
               @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
+              @app_prefs_by_collection = @app_prefs.group_by(&:collection_id)
               render :app_prefs, status: :unprocessable_entity and return
             end
           end
@@ -85,9 +87,8 @@ class AppPreferencesController < ApplicationController
     elsif params[:app_preference].present?
       # create preference for every collection
       Collection.all.each do |collection|
-        @app_preference = AppPreference.new(app_preference_params)
+        @app_preference = collection.app_preferences.build(app_preference_params.except(:collection_id))
         authorize @app_preference
-        @app_preference.collection_id = collection.id
         unless @app_preference.save
           AppPreference.distinct.order(:name).pluck(:name, :description, :pref_type).each {|pref| @app_preferences << pref + ["no"]}
           GlobalPreference.distinct.order(:name).pluck(:name, :description, :pref_type).each {|pref| @app_preferences << pref + ["yes"]}

--- a/app/views/app_preferences/_all_preferences.html.erb
+++ b/app/views/app_preferences/_all_preferences.html.erb
@@ -54,7 +54,7 @@
   <%= form_with model: @app_prefs, url: app_prefs_path, method: :post do |form| %>
     <% @collections.each do |collection| %>
       <h3 class="my-4 ms-6"><%= collection.division %></h3>
-      <% @app_prefs.where(collection_id: collection).each do |pref| %>
+      <% @app_prefs_by_collection.fetch(collection.id, []).each do |pref| %>
         <%= fields_for 'app_prefs[]' do %>
           <div>
             <% if pref.pref_type == "boolean" %>

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AppPreferencesController, type: :request do
           description: "Show barcode",
           pref_type: "boolean"
         }
-      }
+      }, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
       expect(response).to have_http_status(:success)
       expect(AppPreference.where(name: "show_barcode").count).to eq(2)

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe AppPreferencesController, type: :request do
+  let(:developer) { FactoryBot.create(:user) }
+  let!(:mpabi_collection) { FactoryBot.create(:collection, division: "MPABI", admin_group: "mpabi-admins") }
+  let!(:zoo_collection) { FactoryBot.create(:collection, division: "ZOO", admin_group: "zoo-admins") }
+
+  before do
+    uniqname = get_uniqname(developer.email)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(uniqname, "lsa-biorepository-developers").and_return(true)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(uniqname, SUPER_ADMIN_LDAP_GROUP).and_return(false)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(uniqname, "mpabi-admins").and_return(false)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(uniqname, "zoo-admins").and_return(false)
+    mock_login(developer)
+  end
+
+  describe 'GET /app_preferences/app_prefs' do
+    before do
+      FactoryBot.create(:app_preference, collection: mpabi_collection, name: "show_barcode")
+      FactoryBot.create(:app_preference, collection: zoo_collection, name: "show_barcode")
+    end
+
+    it 'renders collection preferences without querying preferences once per collection' do
+      collection_preference_loads = []
+      subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _started, _finished, _unique_id, payload|
+        collection_preference_loads << payload[:sql] if payload[:sql].match?(/SELECT "app_preferences"\.\* FROM "app_preferences" WHERE "app_preferences"\."collection_id" =/)
+      end
+
+      get app_prefs_path
+
+      expect(response).to have_http_status(:success)
+      expect(collection_preference_loads).to be_empty
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+    end
+  end
+
+  describe 'POST /app_preferences' do
+    it 'creates one app preference per collection without reloading each collection' do
+      collection_loads = []
+      subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _started, _finished, _unique_id, payload|
+        collection_loads << payload[:sql] if payload[:sql].match?(/SELECT "collections"\.\* FROM "collections" WHERE "collections"\."id" =/)
+      end
+
+      post app_preferences_path, params: {
+        app_preference: {
+          name: "show_barcode",
+          description: "Show barcode",
+          pref_type: "boolean"
+        }
+      }
+
+      expect(response).to have_http_status(:success)
+      expect(AppPreference.where(name: "show_barcode").count).to eq(2)
+      expect(collection_loads).to be_empty
+    ensure
+      ActiveSupport::Notifications.unsubscribe(subscription) if subscription
+    end
+  end
+end


### PR DESCRIPTION
Fixes N+1 queries on the app preferences views.

**Changes**
- Builds new collection app preferences through collection.app_preferences.build(...) during preference creation, preventing repeated collection lookups while saving.
- Preloads app preferences for the preferences management view by grouping the ordered relation once with group_by(&:collection_id).
- Updates _all_preferences.html.erb to read preferences from the grouped hash instead of calling app_prefs.where(...) inside the collections loop.
- Adds request specs covering: Creating one app preference per collection without reloading each collection.
Rendering /app_preferences/app_prefs without querying app preferences once per collection.

All RSpec tests pass on localhost after second commit.