### PR TITLE
Implement dynamic Preparation Add message

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,6 +100,14 @@ module ApplicationHelper
     end
   end
 
+  def preparation_checkout_label(item)
+    if item&.collection&.no_loan_requests?
+      "Add Preparation to Checkout (Information Request Only)"
+    else
+      "Add Preparation to Checkout"
+    end
+  end
+
   def item_views
     [
       [ 'Rows', 'rows' ],

--- a/app/views/collections/_item_card.html.erb
+++ b/app/views/collections/_item_card.html.erb
@@ -9,7 +9,6 @@
     <p>
       <%= item.coordinates %>
     </p>
-    <%= render partial: "collections/preparation_for_checkout", locals: { item: item, checkout: @checkout } %>
+    <%= render partial: "collections/preparation_for_checkout", locals: { item: item, checkout: @checkout, checkout_label: preparation_checkout_label(item) } %>
   </div>
 </div>
-

--- a/app/views/collections/_preparation_for_checkout.html.erb
+++ b/app/views/collections/_preparation_for_checkout.html.erb
@@ -1,5 +1,5 @@
 <div class="mt-4">
-  <div class="fw-bold fs-6 mb-3">Add Preparation to Checkout</div>
+  <div class="fw-bold fs-6 mb-3"><%= local_assigns.fetch(:checkout_label, "Add Preparation to Checkout") %></div>
   <div class="d-flex flex-wrap gap-2">
 
     <% available_preparations = item.preparations.select(&:available?) %>

--- a/app/views/items/_item_card.html.erb
+++ b/app/views/items/_item_card.html.erb
@@ -9,6 +9,6 @@
     <p>
       <%= item.coordinates %>
     </p>
-    <%= render partial: "collections/preparation_for_checkout", locals: { item: item, checkout: @checkout } %>
+    <%= render partial: "collections/preparation_for_checkout", locals: { item: item, checkout: @checkout, checkout_label: preparation_checkout_label(item) } %>
   </div>
 </div>

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -20,7 +20,7 @@
             Item Details Page 
           <% end %>
           <%= turbo_frame_tag "checkout_item_row_#{item.id}" do %>
-            <%= render partial: "collections/preparation_for_checkout", locals: { item: item } %>
+            <%= render partial: "collections/preparation_for_checkout", locals: { item: item, checkout_label: preparation_checkout_label(item) } %>
           <% end %>
           <table class="table text-center">
             <tbody class="table-group-divider">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -5,7 +5,7 @@
     <h1><%= @item.collection.division %> Collection</h1>
     <h2><%= @item.display_name %></h2>
     <%= turbo_frame_tag "checkout_item_row_#{@item.id}" do %>
-      <%= render partial: "collections/preparation_for_checkout", locals: { item: @item } %>
+      <%= render partial: "collections/preparation_for_checkout", locals: { item: @item, checkout_label: preparation_checkout_label(@item) } %>
     <% end %>
 
     <%= link_to safe_return_path(params[:return_to], collection_path(@item.collection)), class: "btn btn-outline-primary mt-4" do %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#preparation_checkout_label' do
+    it 'returns the standard checkout label for loan request collections' do
+      collection = build(:collection, no_loan_requests: false)
+      item = build(:item, collection: collection)
+
+      expect(helper.preparation_checkout_label(item)).to eq('Add Preparation to Checkout')
+    end
+
+    it 'returns the information-only checkout label for no loan request collections' do
+      collection = build(:collection, no_loan_requests: true)
+      item = build(:item, collection: collection)
+
+      expect(helper.preparation_checkout_label(item)).to eq('Add Preparation to Checkout (Information Request Only)')
+    end
+  end
+end

--- a/spec/requests/items_controller_spec.rb
+++ b/spec/requests/items_controller_spec.rb
@@ -35,6 +35,27 @@ RSpec.describe ItemsController, type: :request do
         # Test that the page includes preparation information
         expect(response.body).to include("Preparation")
       end
+
+      it 'displays the information-only checkout label for no loan request collections' do
+        collection.update!(no_loan_requests: true)
+        FactoryBot.create(:preparation, item: item)
+
+        get item_path(item)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Add Preparation to Checkout (Information Request Only)')
+      end
+
+      it 'displays the standard checkout label for loan request collections' do
+        collection.update!(no_loan_requests: false)
+        FactoryBot.create(:preparation, item: item)
+
+        get item_path(item)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Add Preparation to Checkout')
+        expect(response.body).not_to include('Information Request Only')
+      end
     end
 
     context 'when item does not exist' do
@@ -133,6 +154,78 @@ RSpec.describe ItemsController, type: :request do
       it 'defaults view when no switch_view param' do
         get search_items_path
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'with search result card checkout labels' do
+      it 'displays the information-only checkout label for no loan request collections' do
+        collection.update!(no_loan_requests: true)
+        FactoryBot.create(:preparation, item: item)
+
+        get search_items_path, params: { switch_view: 'cards', q: { id_eq: item.id } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Add Preparation to Checkout (Information Request Only)')
+      end
+
+      it 'displays the standard checkout label for loan request collections' do
+        collection.update!(no_loan_requests: false)
+        FactoryBot.create(:preparation, item: item)
+
+        get search_items_path, params: { switch_view: 'cards', q: { id_eq: item.id } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Add Preparation to Checkout')
+        expect(response.body).not_to include('Information Request Only')
+      end
+
+      it 'does not query collections once per card when rendering dynamic labels' do
+        search_items = 3.times.map do |index|
+          no_loan_collection = FactoryBot.create(
+            :collection,
+            division: "No Loan Search Cards #{index}",
+            admin_group: "no_loan_search_cards_#{index}",
+            no_loan_requests: true
+          )
+          FactoryBot.create(:item, collection: no_loan_collection)
+        end
+        search_items.each do |search_item|
+          FactoryBot.create(:preparation, item: search_item)
+        end
+
+        queries = capture_sql do
+          get search_items_path, params: { switch_view: 'cards', q: { id_in: search_items.map(&:id) } }
+        end
+
+        collection_n_plus_one_queries = queries.select do |sql|
+          sql.match?(/FROM "?collections"? WHERE "?collections"?\."?id"? =/)
+        end
+
+        expect(response).to have_http_status(:ok)
+        expect(collection_n_plus_one_queries).to be_empty
+      end
+    end
+
+    context 'with search result row checkout labels' do
+      it 'displays the information-only checkout label for no loan request collections' do
+        collection.update!(no_loan_requests: true)
+        FactoryBot.create(:preparation, item: item)
+
+        get search_items_path, params: { switch_view: 'rows', q: { id_eq: item.id } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Add Preparation to Checkout (Information Request Only)')
+      end
+
+      it 'displays the standard checkout label for loan request collections' do
+        collection.update!(no_loan_requests: false)
+        FactoryBot.create(:preparation, item: item)
+
+        get search_items_path, params: { switch_view: 'rows', q: { id_eq: item.id } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Add Preparation to Checkout')
+        expect(response.body).not_to include('Information Request Only')
       end
     end
 


### PR DESCRIPTION
Adds a helper-backed dynamic label for preparation checkout sections on item search results and item detail pages. Items from collections marked No Loan Requests now display Add Preparation to Checkout (Information Request Only), while all other items keep the existing Add Preparation to Checkout label.

All RSpec tests pass on local.