### PR TITLE
Add checkout separation for loan vs information requests

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -186,8 +186,10 @@ class CollectionsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def collection_params
-      params.require(:collection).permit(:division, :admin_group, :short_description, :long_description, :division_page_url, :link_to_policies, :image) 
-    end
+  params.require(:collection).permit(:division, :admin_group, :short_description, 
+    :long_description, :division_page_url, :link_to_policies, :image,
+    :accepts_loan_requests)  # ← add this
+end
 
     def search_params
       params.permit(:q1, :commit)

--- a/app/controllers/loan_requests_controller.rb
+++ b/app/controllers/loan_requests_controller.rb
@@ -57,21 +57,22 @@ class LoanRequestsController < ApplicationController
       redirect_to step_four_path and return
     end
     alert = checkout_availability
-    @checkout_items = get_checkout_items_with_ids
+    @checkout_items = get_loan_checkout_items_with_ids
     authorize LoanRequest
     flash.now[:alert] = alert + " preparation(s) are no longer available and have been removed from Checkout." if alert.present?
   end
 
   def send_loan_request
-    @shipping_address = Address.find(params[:shipping_address_id])
+  @shipping_address = Address.find(params[:shipping_address_id])
 
-    if @checkout.nil? || @checkout.requestables.active.empty?
-      flash[:alert] = "No items in checkout."
-      redirect_to root_path
-      return
-    end
+  if @checkout.nil? || @checkout.requestables.active.empty?
+    flash[:alert] = "No items in checkout."
+    redirect_to root_path
+    return
+  end
 
-    @checkout_items, @collection_ids = get_checkout_items
+  @checkout_items, @collection_ids = get_loan_checkout_items
+
 
     emails = @collection_ids.map do |collection_id|
       AppPreference.find_by(
@@ -217,7 +218,9 @@ class LoanRequestsController < ApplicationController
         answer_text = primary_position_answer&.answer&.to_plain_text.presence || "Not Provided"
         # Organism remarks can contain multiple semicolon-delimited segments;
         # for this CSV export we only include the first segment
-        @checkout.requestables.active.each do |requestable|
+        @checkout.requestables.active
+            .select { |r| r.preparation.item.collection.accepts_loan_requests }
+            .each do |requestable|
           csv << [
             [user.first_name, user.last_name].compact.join(" "),
             user.affiliation,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -256,4 +256,41 @@ module ApplicationHelper
     end
   end
 
+  def get_loan_checkout_items
+  checkout_items = []
+  collection_ids = []
+  @checkout.requestables.active
+    .includes(:preparation, item: [:collection, :current_identification])
+    .select { |r| r.preparation.item.collection.accepts_loan_requests }
+    .each do |requestable|
+      preparation = requestable.preparation
+      item = preparation.item
+      checkout_item = "#{item.collection.division}, Catalog Number: #{item.catalog_number}, Scientific Name: #{item.current_identification&.scientific_name}, Preparation: #{preparation.prep_type}"
+      checkout_item += ", Barcode: #{preparation.barcode}" if preparation.barcode.present?
+      checkout_item += ", Description: #{preparation.description}" if preparation.description.present?
+      checkout_item += ", Count: #{requestable.count}"
+      checkout_items << checkout_item
+      collection_ids << item.collection_id
+    end
+  [checkout_items, collection_ids.uniq]
+end
+
+def get_loan_checkout_items_with_ids
+  checkout_items = []
+  @checkout.requestables.active
+    .includes(:preparation, item: [:collection, :current_identification])
+    .select { |r| r.preparation.item.collection.accepts_loan_requests }
+    .each do |requestable|
+      preparation = requestable.preparation
+      item = preparation.item
+      checkout_item = "#{item.collection.division}, Catalog Number: #{item.catalog_number}, Scientific Name: #{item.current_identification&.scientific_name}, Preparation: #{preparation.prep_type}"
+      checkout_item += ", Barcode: #{preparation.barcode}" if preparation.barcode.present?
+      checkout_item += ", Description: #{preparation.description}" if preparation.description.present?
+      checkout_item += ", Count: #{requestable.count}"
+      checkout_item += ", #{item.id}"
+      checkout_items << checkout_item
+    end
+  checkout_items
+ end
+
 end

--- a/app/views/checkout/_checkout.html.erb
+++ b/app/views/checkout/_checkout.html.erb
@@ -3,14 +3,33 @@
     <% is_preview = params[:preview] == "true" && policy(Announcement).preview? %>
     <%= render "layouts/announcement", is_preview: is_preview, location: "checkout" %>
 
-    <h1>Checkout</h1>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-center mb-3">
+  <h1>Checkout</h1>
+  <div class="d-flex gap-2 flex-wrap">
+    <% if user_signed_in? %>
+      <%= link_to new_loan_request_path, class: "btn btn-primary h-50 mb-2", data: { turbo_frame: "_top" } do %>
+        <i class="bi bi-envelope"></i> Send Loan Request
+      <% end %>
+      <%= link_to new_information_request_path, class: "btn btn-outline-primary h-50 mb-2", data: { turbo_frame: "_top" } do %>
+        <i class="bi bi-info-circle"></i> Send Information Request
+      <% end %>
+    <% else %>
+      <%= link_to new_user_session_path, class: "btn btn-primary h-50 mb-2", data: { turbo_frame: "_top" } do %>
+        <i class="bi bi-envelope"></i> Sign In to Send Loan Request
+      <% end %>
+      <%= link_to new_user_session_path, class: "btn btn-outline-primary h-50 mb-2", data: { turbo_frame: "_top" } do %>
+        <i class="bi bi-info-circle"></i> Sign In to Send Information Request
+      <% end %>
+    <% end %>
+  </div>
+</div>
 
     <% if @checkout.requestables.active.exists? %>
 
       <% all_requestables = @checkout.requestables.active.order(:id)
           .includes(:preparation, item: [:collection, :preparations, :current_identification]) %>
-      <% loan_available = all_requestables.select { |r| r.preparation.item.collection.accepts_loan_requests } %>
-      <% loan_unavailable = all_requestables.reject { |r| r.preparation.item.collection.accepts_loan_requests } %>
+      <% loan_available = all_requestables.reject { |r| r.preparation.item.collection.no_loan_requests } %>
+      <% loan_unavailable = all_requestables.select { |r| r.preparation.item.collection.no_loan_requests } %>
 
       <%# ── LOAN REQUEST SECTION ── %>
       <div class="mt-4 p-4 border rounded-3 shadow-sm">
@@ -60,7 +79,7 @@
                           </div>
                         <% end %>
                       </div>
-                      
+
                       <div class="col-md-4 text-start">
                         <%= form_with url: checkout_save_for_later_path, data: { turbo_frame: "checkout" } do |form| %>
                           <%= form.hidden_field :id, value: preparation.id %>
@@ -100,6 +119,23 @@
                       <div class="col-md-4 text-start text-muted">
                         <strong>Preparation Type:</strong> <%= show_preparation(requestable) %>
                       </div>
+                      <!-- ADDED: Count dropdown (previously missing from this section) -->
+                      <div class="col-md-4 text-start mb-2">
+                        <%= form_with url: checkout_change_path,
+                            data: { controller: "autosubmit", autosubmit_target: "form", turbo_frame: "checkout" } do |form| %>
+                          <%= form.hidden_field :id, value: preparation.id %>
+                          <div class="position-relative" style="display:inline-block;">
+                            <%= form.select :count, options_for_select(0..preparation.count, requestable.count), {},
+                                { class: "form-control pe-4 checkout-select",
+                                  "data-action": "change->autosubmit#submit",
+                                  "aria-label": "Select count for #{item.display_name}" } %>
+                            <span class="position-absolute top-50 end-0 translate-middle-y pe-2" style="pointer-events:none;">
+                              <i class="bi bi-caret-down-fill"></i>
+                            </span>
+                          </div>
+                        <% end %>
+                      </div>
+                      <!-- END ADDED -->
                       <div class="col-md-4 text-start">
                         <%= form_with url: checkout_remove_path, data: { turbo_confirm: "Are you sure you want to remove this item?" } do |form| %>
                           <%= form.hidden_field :id, value: requestable.id %>

--- a/app/views/checkout/_checkout.html.erb
+++ b/app/views/checkout/_checkout.html.erb
@@ -2,30 +2,241 @@
   <div class="">
     <% is_preview = params[:preview] == "true" && policy(Announcement).preview? %>
     <%= render "layouts/announcement", is_preview: is_preview, location: "checkout" %>
-    <div class="d-flex flex-column flex-md-row justify-content-between align-items-center">
-      <h1>Checkout</h1>
-      <% if @checkout.requestables.active.exists? %>
-        <% if user_signed_in? %>
-          <%= link_to new_loan_request_path, class: "btn btn-primary h-50 mb-2", data: { turbo_frame: "_top" } do %>
-            <i class="bi bi-envelope"></i> Send Loan Request
-          <% end %>
-        <% else %>
-          <%= link_to new_user_session_path, class: "btn btn-primary h-50 mb-2", data: { turbo_frame: "_top" } do %>
-            <i class="bi bi-envelope"></i> Sign In to Send Loan Request
+
+    <h1>Checkout</h1>
+
+    <% if @checkout.requestables.active.exists? %>
+
+      <% all_requestables = @checkout.requestables.active.order(:id)
+          .includes(:preparation, item: [:collection, :preparations, :current_identification]) %>
+      <% loan_available = all_requestables.select { |r| r.preparation.item.collection.accepts_loan_requests } %>
+      <% loan_unavailable = all_requestables.reject { |r| r.preparation.item.collection.accepts_loan_requests } %>
+
+      <%# ── LOAN REQUEST SECTION ── %>
+      <div class="mt-4 p-4 border rounded-3 shadow-sm">
+        <div class="d-flex align-items-center gap-2 mb-2">
+          <i class="bi bi-box-seam-fill fs-4"></i>
+          <h2 class="mb-0">Loan Request</h2>
+        </div>
+        <p class="text-muted mb-4">Only items from collections that accept loan requests can be included. Uncheck items you don't want to include.</p>
+
+        <% if loan_available.any? %>
+          <h6 class="text-success mb-3"><i class="bi bi-check-circle-fill"></i> Available for Loan</h6>
+          <% loan_available.each do |requestable| %>
+            <% item = requestable.item %>
+            <% preparation = requestable.preparation %>
+            <div class="card mb-3 border-success">
+              <div class="card-body">
+                <div class="d-flex align-items-start gap-3">
+                  <input type="checkbox"
+                         class="form-check-input mt-1 loan-checkbox"
+                         name="loan_items[]"
+                         value="<%= requestable.id %>"
+                         checked
+                         style="width:1.2em;height:1.2em;">
+                  <div class="w-100">
+                    <div class="text-center fw-bold mb-2">
+                      <%= link_to item.display_name, item_path(item), class: "link_to", data: { turbo_frame: "_top" } %>
+                    </div>
+                    <div class="row">
+                      <div class="col-md-4 text-start">
+                        <strong>Collection:</strong> <%= item.collection.division %>
+                      </div>
+                      <div class="col-md-4 text-start">
+                        <strong>Preparation Type:</strong> <%= show_preparation(requestable) %>
+                      </div>
+                      <div class="col-md-4 text-start mb-2">
+                        <%= form_with url: checkout_change_path,
+                            data: { controller: "autosubmit", autosubmit_target: "form", turbo_frame: "checkout" } do |form| %>
+                          <%= form.hidden_field :id, value: preparation.id %>
+                          <div class="position-relative" style="display:inline-block;">
+                            <%= form.select :count, options_for_select(0..preparation.count, requestable.count), {},
+                                { class: "form-control pe-4 checkout-select",
+                                  "data-action": "change->autosubmit#submit",
+                                  "aria-label": "Select count for #{item.display_name}" } %>
+                            <span class="position-absolute top-50 end-0 translate-middle-y pe-2" style="pointer-events:none;">
+                              <i class="bi bi-caret-down-fill"></i>
+                            </span>
+                          </div>
+                        <% end %>
+                      </div>
+                      
+                      <div class="col-md-4 text-start">
+                        <%= form_with url: checkout_save_for_later_path, data: { turbo_frame: "checkout" } do |form| %>
+                          <%= form.hidden_field :id, value: preparation.id %>
+                          <button type="submit" class="btn btn-link">
+                            <i class="bi bi-bookmarks"></i> Save for Later
+                          </button>
+                        <% end %>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           <% end %>
         <% end %>
-      <% end %>
-    </div>
-    <% if @checkout.requestables.active.exists? %>
-      <%= render "checkout/requestables" %>
+
+        <% if loan_unavailable.any? %>
+          <h6 class="text-danger mt-3 mb-3"><i class="bi bi-x-circle-fill"></i> Not Available for Loan</h6>
+          <% loan_unavailable.each do |requestable| %>
+            <% item = requestable.item %>
+            <% preparation = requestable.preparation %>
+            <div class="card mb-3 border-danger opacity-75">
+              <div class="card-body">
+                <div class="d-flex align-items-start gap-3">
+                  <input type="checkbox"
+                         class="form-check-input mt-1"
+                         disabled
+                         style="width:1.2em;height:1.2em;">
+                  <div class="w-100">
+                    <div class="text-center fw-bold mb-2 text-muted">
+                      <%= link_to item.display_name, item_path(item), class: "text-muted", data: { turbo_frame: "_top" } %>
+                    </div>
+                    <div class="row">
+                      <div class="col-md-4 text-start text-muted">
+                        <strong>Collection:</strong> <%= item.collection.division %>
+                      </div>
+                      <div class="col-md-4 text-start text-muted">
+                        <strong>Preparation Type:</strong> <%= show_preparation(requestable) %>
+                      </div>
+                      <div class="col-md-4 text-start">
+                        <%= form_with url: checkout_remove_path, data: { turbo_confirm: "Are you sure you want to remove this item?" } do |form| %>
+                          <%= form.hidden_field :id, value: requestable.id %>
+                          <button type="submit" class="btn btn-link">
+                            <i class="bi bi-trash-fill text-danger"></i> Remove
+                          </button>
+                        <% end %>
+                      </div>
+                      <div class="col-md-4 text-start">
+                        <%= form_with url: checkout_save_for_later_path, data: { turbo_frame: "checkout" } do |form| %>
+                          <%= form.hidden_field :id, value: preparation.id %>
+                          <button type="submit" class="btn btn-link">
+                            <i class="bi bi-bookmarks"></i> Save for Later
+                          </button>
+                        <% end %>
+                      </div>
+                    </div>
+                    <div class="text-danger small mt-1">
+                      <i class="bi bi-info-circle"></i> This collection does not accept loan requests
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+
+        <div class="mt-3">
+          <% if loan_available.any? && user_signed_in? %>
+            <%= link_to new_loan_request_path, class: "btn btn-primary", data: { turbo_frame: "_top" } do %>
+              <i class="bi bi-send"></i> Send Loan Request
+            <% end %>
+          <% elsif !user_signed_in? %>
+            <%= link_to new_user_session_path, class: "btn btn-primary", data: { turbo_frame: "_top" } do %>
+              Sign In to Send Loan Request
+            <% end %>
+          <% else %>
+            <button class="btn btn-primary" disabled>
+              <i class="bi bi-send"></i> Send Loan Request
+            </button>
+            <div class="text-muted small mt-1">No items available for loan in your checkout.</div>
+          <% end %>
+        </div>
+      </div>
+
+      <%# ── INFORMATION REQUEST SECTION ── %>
+      <div class="mt-4 p-4 border rounded-3 shadow-sm">
+        <div class="d-flex align-items-center gap-2 mb-2">
+          <i class="bi bi-info-circle-fill fs-4 text-primary"></i>
+          <h2 class="mb-0">Information Request</h2>
+        </div>
+        <p class="text-muted mb-4">All items in your checkout are included. Uncheck items you don't want to include.</p>
+
+        <% all_requestables.each do |requestable| %>
+          <% item = requestable.item %>
+          <% preparation = requestable.preparation %>
+          <div class="card mb-3">
+            <div class="card-body">
+              <div class="d-flex align-items-start gap-3">
+                <input type="checkbox"
+                       class="form-check-input mt-1 info-checkbox"
+                       name="info_items[]"
+                       value="<%= requestable.id %>"
+                       checked
+                       style="width:1.2em;height:1.2em;">
+                <div class="w-100">
+                  <div class="text-center fw-bold mb-2">
+                    <%= link_to item.display_name, item_path(item), class: "link_to", data: { turbo_frame: "_top" } %>
+                  </div>
+                  <div class="row">
+                    <div class="col-md-4 text-start">
+                      <strong>Collection:</strong> <%= item.collection.division %>
+                    </div>
+                    <div class="col-md-4 text-start">
+                      <strong>Preparation Type:</strong> <%= show_preparation(requestable) %>
+                    </div>
+                    <div class="col-md-4 text-start mb-2">
+                      <%= form_with url: checkout_change_path,
+                          data: { controller: "autosubmit", autosubmit_target: "form", turbo_frame: "checkout" } do |form| %>
+                        <%= form.hidden_field :id, value: preparation.id %>
+                        <div class="position-relative" style="display:inline-block;">
+                          <%= form.select :count, options_for_select(0..preparation.count, requestable.count), {},
+                              { class: "form-control pe-4 checkout-select",
+                                "data-action": "change->autosubmit#submit",
+                                "aria-label": "Select count for #{item.display_name}" } %>
+                          <span class="position-absolute top-50 end-0 translate-middle-y pe-2" style="pointer-events:none;">
+                            <i class="bi bi-caret-down-fill"></i>
+                          </span>
+                        </div>
+                      <% end %>
+                    </div>
+                    <div class="col-md-4 text-start">
+                      <%= form_with url: checkout_remove_path, data: { turbo_confirm: "Are you sure you want to remove this item?" } do |form| %>
+                        <%= form.hidden_field :id, value: requestable.id %>
+                        <button type="submit" class="btn btn-link">
+                          <i class="bi bi-trash-fill text-danger"></i> Remove
+                        </button>
+                      <% end %>
+                    </div>
+                    <div class="col-md-4 text-start">
+                      <%= form_with url: checkout_save_for_later_path, data: { turbo_frame: "checkout" } do |form| %>
+                        <%= form.hidden_field :id, value: preparation.id %>
+                        <button type="submit" class="btn btn-link">
+                          <i class="bi bi-bookmarks"></i> Save for Later
+                        </button>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <div class="mt-3">
+          <% if user_signed_in? %>
+            <%= link_to new_information_request_path, class: "btn btn-outline-primary", data: { turbo_frame: "_top" } do %>
+              <i class="bi bi-send"></i> Send Information Request
+            <% end %>
+          <% else %>
+            <%= link_to new_user_session_path, class: "btn btn-outline-primary", data: { turbo_frame: "_top" } do %>
+              Sign In to Send Information Request
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+
     <% else %>
       <p>Your checkout is empty</p>
     <% end %>
+
     <% if @checkout.unavailables.exists? %>
       <h2 class="py-2">Temporarily Unavailable</h2>
-      <p class="mb-4 alert alert-warning">Preparations for the following items are temporarily unavailable. Please click on the item's name to check when preparations will be available.</p>
+      <p class="mb-4 alert alert-warning">Preparations for the following items are temporarily unavailable.</p>
       <%= render "checkout/unavailables" %>
     <% end %>
+
     <% if @checkout.no_longer_availables.exists? %>
       <h2 class="py-2">No Longer Available</h2>
       <p class="mb-4 alert alert-warning">The following items are no longer available. You can remove them from your Checkout.</p>
@@ -34,9 +245,9 @@
 
     <h2 class="py-2">Saved for Later</h2>
     <% if @checkout.requestables.saved_for_later.exists? %>
-        <%= render "checkout/saved_list" %>
+      <%= render "checkout/saved_list" %>
     <% else %>
-      <p class="mb-4">You don't have any preparations saved for later.</p> 
+      <p class="mb-4">You don't have any preparations saved for later.</p>
     <% end %>
   </div>
 <% end %>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -56,6 +56,13 @@
     </div>
     <%= form.label :image, "Update the Image:", class: "w-100 mb-2" %>
     <%= form.file_field :image, accept: ".jpg,.jpeg,.png" %>
+    <div class="mt-3">
+  <div class="form-check">
+    <%= form.check_box :accepts_loan_requests, class: "form-check-input" %>
+    <%= form.label :accepts_loan_requests, "Accepts Loan Requests", class: "form-check-label" %>
+  </div>
+  <small class="text-muted">Check this if this collection accepts loan requests from users.</small>
+</div>
   </div>
 
   <div class="mt-3 mb-4">
@@ -65,6 +72,13 @@
     <% else %>
       <%= link_to "Cancel", collections_path, class: "link_to" %>
     <% end %>
+    <div class="mt-3">
+  <div class="form-check">
+    <%= form.check_box :accepts_loan_requests, class: "form-check-input" %>
+    <%= form.label :accepts_loan_requests, "Accepts Loan Requests", class: "form-check-label fw-semibold" %>
+  </div>
+  <small class="text-muted">Enable this if this collection accepts loan requests from users.</small>
+</div>
   </div>
 <% end %>
 


### PR DESCRIPTION
- Add accepts_loan_requests boolean to collections
- Split checkout page into Loan Request and Information Request sections
- Loan section shows available/unavailable items with checkboxes
- Filter loan request flow to only include loan-eligible items
- Add accepts_loan_requests toggle to collection admin form