### PR TITLE
Fix information request send n+1 query

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -53,11 +53,16 @@ class RequestMailer < ApplicationMailer
     def get_custom_email_messages(collection_ids, message_type)
       custom_email_messages = {}
       if collection_ids.present?
-        collection_ids.each do |collection_id|
-          collection = Collection.find_by(id: collection_id)
-          next unless collection
-          collection_name = collection.division
-          collection_email_message = AppPreference.find_by(name: message_type, collection_id: collection_id)&.value
+        ids = Array(collection_ids).compact_blank
+        messages_by_collection_id = AppPreference
+          .joins(:collection)
+          .where(name: message_type, collection_id: ids)
+          .where.not(value: [nil, ""])
+          .pluck("app_preferences.collection_id", "collections.division", "app_preferences.value")
+          .index_by { |collection_id, _collection_name, _message| collection_id.to_s }
+
+        ids.each do |collection_id|
+          _id, collection_name, collection_email_message = messages_by_collection_id[collection_id.to_s]
           custom_email_messages[collection_name] = collection_email_message if collection_email_message.present?
         end
       end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe RequestMailer, type: :mailer do
+  describe '#get_custom_email_messages' do
+    it 'loads custom collection messages in one query' do
+      collections = [
+        create(:collection, division: 'Division A', admin_group: 'group-a'),
+        create(:collection, division: 'Division B', admin_group: 'group-b'),
+        create(:collection, division: 'Division C', admin_group: 'group-c')
+      ]
+
+      collections.each do |collection|
+        create(
+          :app_preference,
+          collection: collection,
+          name: 'custom_message_information_request',
+          value: "Message for #{collection.division}"
+        )
+      end
+
+      queries = []
+      subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, _started, _finished, _id, payload|
+        next if payload[:cached] || payload[:name] == 'SCHEMA'
+
+        queries << payload[:sql] if payload[:sql].match?(/FROM "app_preferences"/)
+        queries << payload[:sql] if payload[:sql].match?(/FROM "collections"/)
+      end
+
+      begin
+        result = described_class.new.send(
+          :get_custom_email_messages,
+          collections.map(&:id),
+          'custom_message_information_request'
+        )
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      expect(result).to eq(
+        'Division A' => 'Message for Division A',
+        'Division B' => 'Message for Division B',
+        'Division C' => 'Message for Division C'
+      )
+      expect(queries.length).to eq(1)
+      expect(queries.first).to include('INNER JOIN "collections"')
+    end
+  end
+end


### PR DESCRIPTION
Fixed the N+1 issue Prosopite reported when information requests were being sent on the application.

Tested information requests being sent in various scenarios, all with proper results:
- all items included
- some items included
- no items included

All RSpec tests pass, no failures.
