### PR TITLE
Add radio buttons for 'no_loan_requests' preference

### DIFF
--- a/app/controllers/app_preferences_controller.rb
+++ b/app/controllers/app_preferences_controller.rb
@@ -1,8 +1,4 @@
 class AppPreferencesController < ApplicationController
-  LOAN_REQUESTS_POLICY_PARAM = "loan_requests_policy"
-  LOAN_REQUESTS_ALLOWED = "allowed"
-  INFORMATION_REQUESTS_ONLY = "information_requests_only"
-
   before_action :set_pref_types, only: %i[ index new create]
 
   # GET /app_preferences or /app_preferences.json
@@ -15,8 +11,13 @@ class AppPreferencesController < ApplicationController
   end
 
   def app_prefs
-    @collections = editable_collections
-    @app_prefs = editable_app_preferences.order(:pref_type, :description)
+    if session[:role] == "developer" || session[:role] == "super_admin"
+      @collections = Collection.order(:division)
+      @app_prefs = AppPreference.all.order(:pref_type, :description)
+    else
+      @collections = Collection.where(id: session[:collection_ids]).order(:division)
+      @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
+    end
     @app_prefs_by_collection = @app_prefs.group_by(&:collection_id)
     @global_prefs = GlobalPreference.includes(:image_attachment).all.order(:pref_type, :description)
     authorize @app_prefs
@@ -42,20 +43,38 @@ class AppPreferencesController < ApplicationController
         end
       end
     elsif params[:app_prefs].present?
-      @app_prefs = editable_app_preferences
+      if session[:role] == "developer" || session[:role] == "super_admin"
+        @app_prefs = AppPreference.all
+      else
+        @app_prefs = AppPreference.where(collection_id: session[:collection_ids])
+      end
       authorize @app_prefs
       @app_prefs.where(pref_type: 'boolean').update_all(value: "0")
       params[:app_prefs].each do |collection, p|
         collection_id = collection.to_i
         p.each do |k, v|
-          pref_name, pref_value = app_preference_update_value(k, v)
-          next if pref_name.nil?
+          if k == "loan_requests_policy"
+            if v == "allowed"
+              k = "no_loan_requests"
+              v = "0"
+            elsif v == "information_requests_only"
+              k = "no_loan_requests"
+              v = "1"
+            else
+              next
+            end
+          end
 
-          app_pref = @app_prefs.find_by(collection_id: collection_id, name: pref_name)
-          unless app_pref&.update(value: pref_value)
+          app_pref = @app_prefs.find_by(collection_id: collection_id, name: k)
+          unless app_pref&.update(value: v)
             flash.now[:alert] = "Error updating app preference: #{app_pref&.errors&.full_messages&.join(', ') || 'Preference not found.'}"
-            @collections = editable_collections
-            @app_prefs = editable_app_preferences.order(:pref_type, :description)
+            if session[:role] == "developer" || session[:role] == "super_admin"
+              @collections = Collection.order(:division)
+              @app_prefs = AppPreference.all.order(:pref_type, :description)
+            else
+              @collections = Collection.where(id: session[:collection_ids]).order(:division)
+              @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
+            end
             @app_prefs_by_collection = @app_prefs.group_by(&:collection_id)
             render :app_prefs, status: :unprocessable_entity and return
           end
@@ -142,22 +161,6 @@ class AppPreferencesController < ApplicationController
       @pref_types = AppPreference.pref_types.keys
     end
 
-    def editable_collections
-      if session[:role] == "developer" || session[:role] == "super_admin"
-        Collection.order(:division)
-      else
-        Collection.where(id: session[:collection_ids]).order(:division)
-      end
-    end
-
-    def editable_app_preferences
-      if session[:role] == "developer" || session[:role] == "super_admin"
-        AppPreference.all
-      else
-        AppPreference.where(collection_id: session[:collection_ids])
-      end
-    end
-
     def sync_no_loan_requests_preferences(app_prefs, submitted_prefs)
       collection_ids = app_prefs.where(name: "no_loan_requests").distinct.pluck(:collection_id)
       return if collection_ids.empty?
@@ -166,7 +169,11 @@ class AppPreferencesController < ApplicationController
         collection_id = collection_id.to_i
         next unless collection_ids.include?(collection_id)
 
-        no_loan_requests = no_loan_requests_from_policy(preferences[LOAN_REQUESTS_POLICY_PARAM])
+        if preferences["loan_requests_policy"] == "allowed"
+          no_loan_requests = false
+        elsif preferences["loan_requests_policy"] == "information_requests_only"
+          no_loan_requests = true
+        end
         next if no_loan_requests.nil?
 
         [collection_id, no_loan_requests]
@@ -174,26 +181,6 @@ class AppPreferencesController < ApplicationController
 
       policy_updates.each do |collection_id, no_loan_requests|
         Collection.where(id: collection_id).update_all(no_loan_requests: no_loan_requests)
-      end
-    end
-
-    def app_preference_update_value(param_name, value)
-      if param_name == LOAN_REQUESTS_POLICY_PARAM
-        no_loan_requests = no_loan_requests_from_policy(value)
-        return if no_loan_requests.nil?
-
-        ["no_loan_requests", no_loan_requests ? "1" : "0"]
-      else
-        [param_name, value]
-      end
-    end
-
-    def no_loan_requests_from_policy(policy)
-      case policy
-      when LOAN_REQUESTS_ALLOWED
-        false
-      when INFORMATION_REQUESTS_ONLY
-        true
       end
     end
 

--- a/app/controllers/app_preferences_controller.rb
+++ b/app/controllers/app_preferences_controller.rb
@@ -15,13 +15,8 @@ class AppPreferencesController < ApplicationController
   end
 
   def app_prefs
-    if session[:role] == "developer" || session[:role] == "super_admin"
-      @collections = Collection.order(:division)
-      @app_prefs = AppPreference.all.order(:pref_type, :description)
-    else
-      @collections = Collection.where(id: session[:collection_ids]).order(:division)  
-      @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
-    end
+    @collections = editable_collections
+    @app_prefs = editable_app_preferences.order(:pref_type, :description)
     @app_prefs_by_collection = @app_prefs.group_by(&:collection_id)
     @global_prefs = GlobalPreference.includes(:image_attachment).all.order(:pref_type, :description)
     authorize @app_prefs
@@ -47,7 +42,7 @@ class AppPreferencesController < ApplicationController
         end
       end
     elsif params[:app_prefs].present?
-      @app_prefs = AppPreference.where(collection_id: session[:collection_ids])
+      @app_prefs = editable_app_preferences
       authorize @app_prefs
       @app_prefs.where(pref_type: 'boolean').update_all(value: "0")
       params[:app_prefs].each do |collection, p|
@@ -56,11 +51,11 @@ class AppPreferencesController < ApplicationController
           pref_name, pref_value = app_preference_update_value(k, v)
           next if pref_name.nil?
 
-          app_pref = AppPreference.find_by(collection_id: collection_id, name: pref_name)
+          app_pref = @app_prefs.find_by(collection_id: collection_id, name: pref_name)
           unless app_pref&.update(value: pref_value)
             flash.now[:alert] = "Error updating app preference: #{app_pref&.errors&.full_messages&.join(', ') || 'Preference not found.'}"
-            @collections = Collection.where(id: session[:collection_ids]).order(:division)
-            @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
+            @collections = editable_collections
+            @app_prefs = editable_app_preferences.order(:pref_type, :description)
             @app_prefs_by_collection = @app_prefs.group_by(&:collection_id)
             render :app_prefs, status: :unprocessable_entity and return
           end
@@ -145,6 +140,22 @@ class AppPreferencesController < ApplicationController
 
     def set_pref_types
       @pref_types = AppPreference.pref_types.keys
+    end
+
+    def editable_collections
+      if session[:role] == "developer" || session[:role] == "super_admin"
+        Collection.order(:division)
+      else
+        Collection.where(id: session[:collection_ids]).order(:division)
+      end
+    end
+
+    def editable_app_preferences
+      if session[:role] == "developer" || session[:role] == "super_admin"
+        AppPreference.all
+      else
+        AppPreference.where(collection_id: session[:collection_ids])
+      end
     end
 
     def sync_no_loan_requests_preferences(app_prefs, submitted_prefs)

--- a/app/controllers/app_preferences_controller.rb
+++ b/app/controllers/app_preferences_controller.rb
@@ -1,4 +1,8 @@
 class AppPreferencesController < ApplicationController
+  LOAN_REQUESTS_POLICY_PARAM = "loan_requests_policy"
+  LOAN_REQUESTS_ALLOWED = "allowed"
+  INFORMATION_REQUESTS_ONLY = "information_requests_only"
+
   before_action :set_pref_types, only: %i[ index new create]
 
   # GET /app_preferences or /app_preferences.json
@@ -49,8 +53,11 @@ class AppPreferencesController < ApplicationController
       params[:app_prefs].each do |collection, p|
         collection_id = collection.to_i
         p.each do |k, v|
-          app_pref = AppPreference.find_by(collection_id: collection_id, name: k)
-          unless app_pref&.update(value: v)
+          pref_name, pref_value = app_preference_update_value(k, v)
+          next if pref_name.nil?
+
+          app_pref = AppPreference.find_by(collection_id: collection_id, name: pref_name)
+          unless app_pref&.update(value: pref_value)
             flash.now[:alert] = "Error updating app preference: #{app_pref&.errors&.full_messages&.join(', ') || 'Preference not found.'}"
             @collections = Collection.where(id: session[:collection_ids]).order(:division)
             @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
@@ -144,14 +151,39 @@ class AppPreferencesController < ApplicationController
       collection_ids = app_prefs.where(name: "no_loan_requests").distinct.pluck(:collection_id)
       return if collection_ids.empty?
 
-      enabled_collection_ids = submitted_prefs.to_unsafe_h.filter_map do |collection_id, preferences|
-        collection_id.to_i if preferences["no_loan_requests"].present?
+      policy_updates = submitted_prefs.to_unsafe_h.filter_map do |collection_id, preferences|
+        collection_id = collection_id.to_i
+        next unless collection_ids.include?(collection_id)
+
+        no_loan_requests = no_loan_requests_from_policy(preferences[LOAN_REQUESTS_POLICY_PARAM])
+        next if no_loan_requests.nil?
+
+        [collection_id, no_loan_requests]
       end
 
-      enabled_collection_ids &= collection_ids
+      policy_updates.each do |collection_id, no_loan_requests|
+        Collection.where(id: collection_id).update_all(no_loan_requests: no_loan_requests)
+      end
+    end
 
-      Collection.where(id: collection_ids).update_all(no_loan_requests: false)
-      Collection.where(id: enabled_collection_ids).update_all(no_loan_requests: true) if enabled_collection_ids.any?
+    def app_preference_update_value(param_name, value)
+      if param_name == LOAN_REQUESTS_POLICY_PARAM
+        no_loan_requests = no_loan_requests_from_policy(value)
+        return if no_loan_requests.nil?
+
+        ["no_loan_requests", no_loan_requests ? "1" : "0"]
+      else
+        [param_name, value]
+      end
+    end
+
+    def no_loan_requests_from_policy(policy)
+      case policy
+      when LOAN_REQUESTS_ALLOWED
+        false
+      when INFORMATION_REQUESTS_ONLY
+        true
+      end
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/app_preferences_controller.rb
+++ b/app/controllers/app_preferences_controller.rb
@@ -43,11 +43,7 @@ class AppPreferencesController < ApplicationController
         end
       end
     elsif params[:app_prefs].present?
-      if session[:role] == "developer" || session[:role] == "super_admin"
-        @app_prefs = AppPreference.all
-      else
-        @app_prefs = AppPreference.where(collection_id: session[:collection_ids])
-      end
+      @app_prefs = AppPreference.where(collection_id: session[:collection_ids])
       authorize @app_prefs
       @app_prefs.where(pref_type: 'boolean').update_all(value: "0")
       params[:app_prefs].each do |collection, p|
@@ -68,13 +64,8 @@ class AppPreferencesController < ApplicationController
           app_pref = @app_prefs.find_by(collection_id: collection_id, name: k)
           unless app_pref&.update(value: v)
             flash.now[:alert] = "Error updating app preference: #{app_pref&.errors&.full_messages&.join(', ') || 'Preference not found.'}"
-            if session[:role] == "developer" || session[:role] == "super_admin"
-              @collections = Collection.order(:division)
-              @app_prefs = AppPreference.all.order(:pref_type, :description)
-            else
-              @collections = Collection.where(id: session[:collection_ids]).order(:division)
-              @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
-            end
+            @collections = Collection.where(id: session[:collection_ids]).order(:division)
+            @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
             @app_prefs_by_collection = @app_prefs.group_by(&:collection_id)
             render :app_prefs, status: :unprocessable_entity and return
           end

--- a/app/controllers/app_preferences_controller.rb
+++ b/app/controllers/app_preferences_controller.rb
@@ -67,6 +67,7 @@ class AppPreferencesController < ApplicationController
             @collections = Collection.where(id: session[:collection_ids]).order(:division)
             @app_prefs = AppPreference.where(collection_id: session[:collection_ids]).order(:pref_type, :description)
             @app_prefs_by_collection = @app_prefs.group_by(&:collection_id)
+            @global_prefs = GlobalPreference.includes(:image_attachment).all.order(:pref_type, :description)
             render :app_prefs, status: :unprocessable_entity and return
           end
         end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -55,6 +55,7 @@ class CollectionsController < ApplicationController
     respond_to do |format|
       if @collection.save
         # create preferences for the collection
+        session[:collection_ids] << @collection.id
         pref_errors = create_app_preferences(@collection)
         notice_message = if pref_errors
           "Collection was successfully created, but there were errors creating App Preferences. Please contact support."

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -87,7 +87,7 @@ class CollectionsController < ApplicationController
   # DELETE /collections/1 or /collections/1.json
   def destroy
     @collection.destroy!
-
+    session[:collection_ids].delete(@collection.id)
     respond_to do |format|
       format.html { redirect_to collections_path, status: :see_other, notice: "Collection was successfully destroyed." }
       format.json { head :no_content }

--- a/app/views/app_preferences/_all_preferences.html.erb
+++ b/app/views/app_preferences/_all_preferences.html.erb
@@ -61,7 +61,7 @@
               <% allowed_input_id = "app_prefs_#{collection.id}_loan_requests_policy_allowed" %>
               <% information_requests_only_input_id = "app_prefs_#{collection.id}_loan_requests_policy_information_requests_only" %>
               <fieldset class="my-3">
-                <legend class="fs-6">Loan Requests</legend>
+                <legend class="fs-6"><%= pref.description %></legend>
                 <div class="form-check">
                   <%= radio_button_tag "app_prefs[#{collection.id}][loan_requests_policy]", "allowed", !collection.no_loan_requests?, id: allowed_input_id, class: "form-check-input" %>
                   <%= label_tag allowed_input_id, "Collection allows Loan Requests", class: "form-check-label" %>

--- a/app/views/app_preferences/_all_preferences.html.erb
+++ b/app/views/app_preferences/_all_preferences.html.erb
@@ -61,15 +61,15 @@
               <% allowed_input_id = "app_prefs_#{collection.id}_loan_requests_policy_allowed" %>
               <% information_requests_only_input_id = "app_prefs_#{collection.id}_loan_requests_policy_information_requests_only" %>
               <fieldset class="my-3">
-                <legend class="fs-6"><%= t("app_preferences.loan_requests_policy.legend") %></legend>
+                <legend class="fs-6">Loan Requests</legend>
                 <div class="form-check">
                   <%= radio_button_tag "app_prefs[#{collection.id}][loan_requests_policy]", "allowed", !collection.no_loan_requests?, id: allowed_input_id, class: "form-check-input" %>
-                  <%= label_tag allowed_input_id, t("app_preferences.loan_requests_policy.allowed.label"), class: "form-check-label" %>
+                  <%= label_tag allowed_input_id, "Collection allows Loan Requests", class: "form-check-label" %>
                 </div>
                 <div class="form-check">
                   <%= radio_button_tag "app_prefs[#{collection.id}][loan_requests_policy]", "information_requests_only", collection.no_loan_requests?, id: information_requests_only_input_id, class: "form-check-input" %>
-                  <%= label_tag information_requests_only_input_id, t("app_preferences.loan_requests_policy.information_requests_only.label"), class: "form-check-label" %>
-                  <div class="form-text"><%= t("app_preferences.loan_requests_policy.information_requests_only.description") %></div>
+                  <%= label_tag information_requests_only_input_id, "Collection doesn’t allow Loan Requests", class: "form-check-label" %>
+                  <div class="form-text">Information Requests only</div>
                 </div>
               </fieldset>
             <% elsif pref.pref_type == "boolean" %>

--- a/app/views/app_preferences/_all_preferences.html.erb
+++ b/app/views/app_preferences/_all_preferences.html.erb
@@ -57,7 +57,22 @@
       <% @app_prefs_by_collection.fetch(collection.id, []).each do |pref| %>
         <%= fields_for 'app_prefs[]' do %>
           <div>
-            <% if pref.pref_type == "boolean" %>
+            <% if pref.name == "no_loan_requests" %>
+              <% allowed_input_id = "app_prefs_#{collection.id}_loan_requests_policy_allowed" %>
+              <% information_requests_only_input_id = "app_prefs_#{collection.id}_loan_requests_policy_information_requests_only" %>
+              <fieldset class="my-3">
+                <legend class="fs-6"><%= t("app_preferences.loan_requests_policy.legend") %></legend>
+                <div class="form-check">
+                  <%= radio_button_tag "app_prefs[#{collection.id}][loan_requests_policy]", "allowed", !collection.no_loan_requests?, id: allowed_input_id, class: "form-check-input" %>
+                  <%= label_tag allowed_input_id, t("app_preferences.loan_requests_policy.allowed.label"), class: "form-check-label" %>
+                </div>
+                <div class="form-check">
+                  <%= radio_button_tag "app_prefs[#{collection.id}][loan_requests_policy]", "information_requests_only", collection.no_loan_requests?, id: information_requests_only_input_id, class: "form-check-input" %>
+                  <%= label_tag information_requests_only_input_id, t("app_preferences.loan_requests_policy.information_requests_only.label"), class: "form-check-label" %>
+                  <div class="form-text"><%= t("app_preferences.loan_requests_policy.information_requests_only.description") %></div>
+                </div>
+              </fieldset>
+            <% elsif pref.pref_type == "boolean" %>
               <% input_id = "app_prefs_#{collection.id}_#{pref.name}" %>
               <div class="form-check form-switch my-3">
                 <%= check_box_tag "app_prefs[#{collection.id}][#{pref.name}]", 1, string_to_boolean(pref.value), id: input_id, class: "form-check-input", role: "switch" %>

--- a/app/views/app_preferences/_all_preferences.html.erb
+++ b/app/views/app_preferences/_all_preferences.html.erb
@@ -68,8 +68,9 @@
                 </div>
                 <div class="form-check">
                   <%= radio_button_tag "app_prefs[#{collection.id}][loan_requests_policy]", "information_requests_only", collection.no_loan_requests?, id: information_requests_only_input_id, class: "form-check-input" %>
-                  <%= label_tag information_requests_only_input_id, "Collection doesn’t allow Loan Requests", class: "form-check-label" %>
-                  <div class="form-text">Information Requests only</div>
+                  <%= label_tag information_requests_only_input_id, class: "form-check-label" do %>
+                    Collection doesn’t allow Loan Requests <span class="text-muted ms-2">Information Requests only</span>
+                  <% end %>
                 </div>
               </fieldset>
             <% elsif pref.pref_type == "boolean" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,11 @@
 
 en:
   hello: "Hello world"
+  app_preferences:
+    loan_requests_policy:
+      legend: "Loan Requests"
+      allowed:
+        label: "Collection allows Loan Requests"
+      information_requests_only:
+        label: "Collection doesn’t allow Loan Requests"
+        description: "Information Requests only"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,11 +29,3 @@
 
 en:
   hello: "Hello world"
-  app_preferences:
-    loan_requests_policy:
-      legend: "Loan Requests"
-      allowed:
-        label: "Collection allows Loan Requests"
-      information_requests_only:
-        label: "Collection doesn’t allow Loan Requests"
-        description: "Information Requests only"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,7 +115,7 @@ app_preferences = [
   },
   {
     name: "no_loan_requests",
-    description: "The collection doesnt allow loan request for preparations",
+    description: "Loan request policy",
     pref_type: "boolean",
     value: "0"
   },

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -170,23 +170,6 @@ RSpec.describe AppPreferencesController, type: :request do
       expect(zoo_collection.reload.no_loan_requests).to be true
     end
 
-    it 'stores elevated user changes for collections outside their admin collection ids' do
-      uniqname = get_uniqname(developer.email)
-      allow(LdapLookup).to receive(:is_member_of_group?).with(uniqname, "mpabi-admins").and_return(true)
-      mock_login(developer)
-
-      post app_prefs_path, params: {
-        app_prefs: {
-          zoo_collection.id => {
-            loan_requests_policy: "information_requests_only"
-          }
-        }
-      }
-
-      expect(response).to redirect_to(app_prefs_path)
-      expect(zoo_collection.reload.no_loan_requests).to be true
-    end
-
     it 'preserves an existing no_loan_requests value when the policy parameter is absent' do
       mpabi_collection.update!(no_loan_requests: true)
       FactoryBot.create(:app_preference, collection: mpabi_collection, name: "show_barcode", pref_type: :boolean, value: "0")

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -41,6 +41,61 @@ RSpec.describe AppPreferencesController, type: :request do
 
       expect(response.body).to include('placeholder="Enter catalog prefix"')
     end
+
+    it 'renders no_loan_requests as a radio group instead of a switch' do
+      FactoryBot.create(:app_preference, collection: mpabi_collection, name: "no_loan_requests", pref_type: :boolean)
+
+      get app_prefs_path
+
+      document = Nokogiri::HTML(response.body)
+      fieldset = document.at_css('fieldset')
+
+      expect(response.body).not_to include('name="app_prefs[' + mpabi_collection.id.to_s + '][no_loan_requests]"')
+      expect(fieldset.at_css('legend').text).to eq("Loan Requests")
+      expect(fieldset.css('input[type="radio"][name="app_prefs[' + mpabi_collection.id.to_s + '][loan_requests_policy]"]').map { |input| input["value"] }).to contain_exactly("allowed", "information_requests_only")
+      expect(fieldset.text).to include("Collection allows Loan Requests")
+      expect(fieldset.text).to include("Collection doesn’t allow Loan Requests")
+      expect(fieldset.text).to include("Information Requests only")
+    end
+
+    it 'selects the allows option when loan requests are allowed' do
+      mpabi_collection.update!(no_loan_requests: false)
+      FactoryBot.create(:app_preference, collection: mpabi_collection, name: "no_loan_requests", pref_type: :boolean)
+
+      get app_prefs_path
+
+      document = Nokogiri::HTML(response.body)
+      allowed = document.at_css('input[type="radio"][name="app_prefs[' + mpabi_collection.id.to_s + '][loan_requests_policy]"][value="allowed"]')
+      information_requests_only = document.at_css('input[type="radio"][name="app_prefs[' + mpabi_collection.id.to_s + '][loan_requests_policy]"][value="information_requests_only"]')
+
+      expect(allowed["checked"]).to eq("checked")
+      expect(information_requests_only["checked"]).to be_nil
+    end
+
+    it 'selects the information requests only option when loan requests are disabled' do
+      mpabi_collection.update!(no_loan_requests: true)
+      FactoryBot.create(:app_preference, collection: mpabi_collection, name: "no_loan_requests", pref_type: :boolean)
+
+      get app_prefs_path
+
+      document = Nokogiri::HTML(response.body)
+      allowed = document.at_css('input[type="radio"][name="app_prefs[' + mpabi_collection.id.to_s + '][loan_requests_policy]"][value="allowed"]')
+      information_requests_only = document.at_css('input[type="radio"][name="app_prefs[' + mpabi_collection.id.to_s + '][loan_requests_policy]"][value="information_requests_only"]')
+
+      expect(allowed["checked"]).to be_nil
+      expect(information_requests_only["checked"]).to eq("checked")
+    end
+
+    it 'selects the allows option by default when no preference value is set' do
+      FactoryBot.create(:app_preference, collection: mpabi_collection, name: "no_loan_requests", pref_type: :boolean, value: nil)
+
+      get app_prefs_path
+
+      document = Nokogiri::HTML(response.body)
+      allowed = document.at_css('input[type="radio"][name="app_prefs[' + mpabi_collection.id.to_s + '][loan_requests_policy]"][value="allowed"]')
+
+      expect(allowed["checked"]).to eq("checked")
+    end
   end
 
   describe 'POST /app_preferences' do

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe AppPreferencesController, type: :request do
     end
 
     it 'renders no_loan_requests as a radio group instead of a switch' do
-      FactoryBot.create(:app_preference, collection: mpabi_collection, name: "no_loan_requests", pref_type: :boolean)
+      FactoryBot.create(:app_preference, collection: mpabi_collection, name: "no_loan_requests", description: "Loan request policy", pref_type: :boolean)
 
       get app_prefs_path
 
@@ -51,7 +51,7 @@ RSpec.describe AppPreferencesController, type: :request do
       fieldset = document.at_css('fieldset')
 
       expect(response.body).not_to include('name="app_prefs[' + mpabi_collection.id.to_s + '][no_loan_requests]"')
-      expect(fieldset.at_css('legend').text).to eq("Loan Requests")
+      expect(fieldset.at_css('legend').text).to eq("Loan request policy")
       expect(fieldset.css('input[type="radio"][name="app_prefs[' + mpabi_collection.id.to_s + '][loan_requests_policy]"]').map { |input| input["value"] }).to contain_exactly("allowed", "information_requests_only")
       expect(fieldset.text).to include("Collection allows Loan Requests")
       expect(fieldset.text).to include("Collection doesn’t allow Loan Requests")

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -141,35 +141,64 @@ RSpec.describe AppPreferencesController, type: :request do
       FactoryBot.create(:app_preference, collection: zoo_collection, name: "no_loan_requests", pref_type: :boolean, value: "0")
     end
 
-    it 'syncs enabled no_loan_requests preferences to collections' do
+    it 'stores no_loan_requests as false when loan requests are allowed' do
+      mpabi_collection.update!(no_loan_requests: true)
+
       post app_prefs_path, params: {
         app_prefs: {
           mpabi_collection.id => {
-            no_loan_requests: "1"
-          }
-        }
-      }
-
-      expect(response).to redirect_to(app_prefs_path)
-      expect(mpabi_collection.reload.no_loan_requests).to be true
-      expect(zoo_collection.reload.no_loan_requests).to be false
-    end
-
-    it 'syncs unchecked no_loan_requests preferences to false on collections' do
-      mpabi_collection.update!(no_loan_requests: true)
-      zoo_collection.update!(no_loan_requests: true)
-
-      post app_prefs_path, params: {
-        app_prefs: {
-          zoo_collection.id => {
-            no_loan_requests: "1"
+            loan_requests_policy: "allowed"
           }
         }
       }
 
       expect(response).to redirect_to(app_prefs_path)
       expect(mpabi_collection.reload.no_loan_requests).to be false
+      expect(zoo_collection.reload.no_loan_requests).to be false
+    end
+
+    it 'stores no_loan_requests as true when only information requests are allowed' do
+      post app_prefs_path, params: {
+        app_prefs: {
+          zoo_collection.id => {
+            loan_requests_policy: "information_requests_only"
+          }
+        }
+      }
+
+      expect(response).to redirect_to(app_prefs_path)
       expect(zoo_collection.reload.no_loan_requests).to be true
+    end
+
+    it 'preserves an existing no_loan_requests value when the policy parameter is absent' do
+      mpabi_collection.update!(no_loan_requests: true)
+      FactoryBot.create(:app_preference, collection: mpabi_collection, name: "show_barcode", pref_type: :boolean, value: "0")
+
+      post app_prefs_path, params: {
+        app_prefs: {
+          mpabi_collection.id => {
+            show_barcode: "1"
+          }
+        }
+      }
+
+      expect(response).to redirect_to(app_prefs_path)
+      expect(mpabi_collection.reload.no_loan_requests).to be true
+    end
+
+    it 'does not interpret unexpected policy values as true' do
+      mpabi_collection.update!(no_loan_requests: false)
+
+      post app_prefs_path, params: {
+        app_prefs: {
+          mpabi_collection.id => {
+            loan_requests_policy: "yes_please"
+          }
+        }
+      }
+
+      expect(response).to redirect_to(app_prefs_path)
+      expect(mpabi_collection.reload.no_loan_requests).to be false
     end
   end
 end

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -170,6 +170,23 @@ RSpec.describe AppPreferencesController, type: :request do
       expect(zoo_collection.reload.no_loan_requests).to be true
     end
 
+    it 'stores elevated user changes for collections outside their admin collection ids' do
+      uniqname = get_uniqname(developer.email)
+      allow(LdapLookup).to receive(:is_member_of_group?).with(uniqname, "mpabi-admins").and_return(true)
+      mock_login(developer)
+
+      post app_prefs_path, params: {
+        app_prefs: {
+          zoo_collection.id => {
+            loan_requests_policy: "information_requests_only"
+          }
+        }
+      }
+
+      expect(response).to redirect_to(app_prefs_path)
+      expect(zoo_collection.reload.no_loan_requests).to be true
+    end
+
     it 'preserves an existing no_loan_requests value when the policy parameter is absent' do
       mpabi_collection.update!(no_loan_requests: true)
       FactoryBot.create(:app_preference, collection: mpabi_collection, name: "show_barcode", pref_type: :boolean, value: "0")

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -200,5 +200,61 @@ RSpec.describe AppPreferencesController, type: :request do
       expect(response).to redirect_to(app_prefs_path)
       expect(mpabi_collection.reload.no_loan_requests).to be false
     end
+
+    it 'checks that preferences are created for existing collections when a new preference is added' do
+      extra_collection = FactoryBot.create(:collection, division: "old_collection", admin_group: "old-admins")
+      preference_name = "enable_dashboard_banner"
+
+      expect do
+        post app_preferences_path, params: {
+          app_preference: {
+            name: preference_name,
+            description: "Enable dashboard banner",
+            pref_type: "boolean"
+          }
+        }, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+      end.to change { AppPreference.where(name: preference_name).count }.by(Collection.count)
+
+      expect(response).to have_http_status(:success)
+      expect(AppPreference.where(name: preference_name).pluck(:collection_id)).to match_array([mpabi_collection.id, zoo_collection.id, extra_collection.id])
+    end
+    
+    it 'checks that preferences are updated correctly after a new collection is added' do
+      preference_name = "enable_dashboard_banner"
+
+      # Create the preference for existing collections
+      post app_preferences_path, params: {
+        app_preference: {
+          name: preference_name,
+          description: "Enable dashboard banner",
+          pref_type: "boolean"
+        }
+      }, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      post collections_path, params: {
+        collection: {
+          division: "new_collection",
+          admin_group: "new-admins",
+          short_description: "New collection",
+          long_description: "New collection long description",
+          division_page_url: "https://example.edu/new_collection",
+          link_to_policies: "https://example.edu/new_collection/policies"
+        }
+      }
+      new_collection = Collection.find_by!(division: "new_collection")
+      
+      # Now update the preference for the new collection
+      post app_prefs_path, params: {
+        app_prefs: {
+          new_collection.id => {
+            enable_dashboard_banner: "1"
+          }
+        }
+      }
+
+      expect(response).to redirect_to(app_prefs_path)
+      expect(AppPreference.find_by(collection_id: new_collection.id, name: preference_name).value).to eq("1")
+    end
+
   end
 end


### PR DESCRIPTION
Replaces the no_loan_requests App Preferences switch with a two-option radio group while preserving the existing collection.no_loan_requests boolean field.

Behavior:
Any preference titled "no_loan_requests" will be treated as a special case that functions as a 2-button fieldset. The "Description" field for the preference is displayed as the title text above the radio button options.

- Updated the seed description for no_loan_requests.
- Renders no_loan_requests as a fieldset with two radio options:Collection allows Loan Requests -> no_loan_requests = false
- Collection doesn’t allow Loan Requests -> no_loan_requests = true
- Submits an explicit loan request policy choice and maps it to the existing no_loan_requests boolean.
- Added RSpec test for proper handling of this preference