### PR TITLE
Fix app preference creation when no collections exist.

### DIFF
--- a/app/controllers/app_preferences_controller.rb
+++ b/app/controllers/app_preferences_controller.rb
@@ -98,23 +98,25 @@ class AppPreferencesController < ApplicationController
       end
     elsif params[:app_preference].present?
       if Collection.none?
-        @app_preference = AppPreference.new(app_preference_params)
-        authorize @app_preference
-        AppPreference.distinct.order(:name).pluck(:name, :description, :pref_type, :placeholder).each {|pref| @app_preferences << pref + ["no"]}
-        GlobalPreference.distinct.order(:name).pluck(:name, :description, :pref_type, :placeholder).each {|pref| @app_preferences << pref + ["yes"]}
-        flash.now[:alert] = "Create a collection before creating App Preferences."
-        return
-      end
-
-      # create preference for every collection
-      Collection.all.each do |collection|
-        @app_preference = collection.app_preferences.build(app_preference_params.except(:collection_id))
+        @app_preference = AppPreference.new(app_preference_params.except(:collection_id))
         authorize @app_preference
         unless @app_preference.save
           AppPreference.distinct.order(:name).pluck(:name, :description, :pref_type, :placeholder).each {|pref| @app_preferences << pref + ["no"]}
           GlobalPreference.distinct.order(:name).pluck(:name, :description, :pref_type, :placeholder).each {|pref| @app_preferences << pref + ["yes"]}
           flash.now[:alert] = "Error creating app preference."
           return
+        end
+      else
+        # create preference for every collection
+        Collection.all.each do |collection|
+          @app_preference = collection.app_preferences.build(app_preference_params.except(:collection_id))
+          authorize @app_preference
+          unless @app_preference.save
+            AppPreference.distinct.order(:name).pluck(:name, :description, :pref_type, :placeholder).each {|pref| @app_preferences << pref + ["no"]}
+            GlobalPreference.distinct.order(:name).pluck(:name, :description, :pref_type, :placeholder).each {|pref| @app_preferences << pref + ["yes"]}
+            flash.now[:alert] = "Error creating app preference."
+            return
+          end
         end
       end
     end

--- a/app/controllers/app_preferences_controller.rb
+++ b/app/controllers/app_preferences_controller.rb
@@ -97,6 +97,15 @@ class AppPreferencesController < ApplicationController
         return
       end
     elsif params[:app_preference].present?
+      if Collection.none?
+        @app_preference = AppPreference.new(app_preference_params)
+        authorize @app_preference
+        AppPreference.distinct.order(:name).pluck(:name, :description, :pref_type, :placeholder).each {|pref| @app_preferences << pref + ["no"]}
+        GlobalPreference.distinct.order(:name).pluck(:name, :description, :pref_type, :placeholder).each {|pref| @app_preferences << pref + ["yes"]}
+        flash.now[:alert] = "Create a collection before creating App Preferences."
+        return
+      end
+
       # create preference for every collection
       Collection.all.each do |collection|
         @app_preference = collection.app_preferences.build(app_preference_params.except(:collection_id))

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -173,10 +173,10 @@ class CollectionsController < ApplicationController
 
     def create_app_preferences(collection)
       # intentionally use all distinct AppPreferences as template/default preferences to copy into this new collection
-      app_prefs = AppPreference.distinct(:name).pluck(:name, :description, :pref_type)
+      app_prefs = AppPreference.select(:name, :description, :pref_type, :placeholder).distinct.pluck(:name, :description, :pref_type, :placeholder)
       pref_errors = false
-      app_prefs.each do |name, description, pref_type|
-        app_pref = AppPreference.create(collection: collection, name: name, description: description, pref_type: pref_type, value: nil)
+      app_prefs.each do |name, description, pref_type, placeholder|
+        app_pref = AppPreference.create(collection: collection, name: name, description: description, pref_type: pref_type, placeholder: placeholder, value: nil)
         unless app_pref.persisted?
           Rails.logger.error "Failed to create AppPreference: #{app_pref.errors.full_messages.join(', ')}"
           pref_errors = true

--- a/app/models/app_preference.rb
+++ b/app/models/app_preference.rb
@@ -10,7 +10,7 @@
 #  value         :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  collection_id :bigint           not null
+#  collection_id :bigint
 #
 # Indexes
 #
@@ -21,7 +21,7 @@
 #  fk_rails_...  (collection_id => collections.id)
 #
 class AppPreference < ApplicationRecord
-  belongs_to :collection
+  belongs_to :collection, optional: true
 
   enum :pref_type, [:boolean, :integer, :string, :image], prefix: true, scopes: true
   

--- a/db/migrate/20260721120000_allow_app_preferences_without_collections.rb
+++ b/db/migrate/20260721120000_allow_app_preferences_without_collections.rb
@@ -1,0 +1,5 @@
+class AllowAppPreferencesWithoutCollections < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :app_preferences, :collection_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_171000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -80,7 +80,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_171000) do
   end
 
   create_table "app_preferences", force: :cascade do |t|
-    t.bigint "collection_id", null: false
+    t.bigint "collection_id"
     t.datetime "created_at", null: false
     t.string "description"
     t.string "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -128,6 +128,19 @@ app_preferences = [
   }
 ]
 
+app_preferences.each do |pref|
+  app_preference = AppPreference.find_or_create_by!(
+    collection_id: nil,
+    name: pref[:name]
+  ) do |ap|
+    ap.description = pref[:description]
+    ap.pref_type = pref[:pref_type]
+    ap.value = pref[:value]
+    ap.placeholder = pref[:placeholder]
+  end
+  app_preference.update!(placeholder: pref[:placeholder]) if pref[:placeholder].present? && app_preference.placeholder.blank?
+end
+
 Collection.all.each do |collection|
   app_preferences.each do |pref|
     app_preference = AppPreference.find_or_create_by!(
@@ -142,7 +155,7 @@ Collection.all.each do |collection|
     app_preference.update!(placeholder: pref[:placeholder]) if pref[:placeholder].present? && app_preference.placeholder.blank?
   end
 end
-puts "App preferences seeded for #{Collection.count} collections (#{AppPreference.count} total records)"
+puts "App preferences seeded as templates and for #{Collection.count} collections (#{AppPreference.count} total records)"
 
 global_preferences = [
   {

--- a/spec/factories/app_preferences.rb
+++ b/spec/factories/app_preferences.rb
@@ -10,7 +10,7 @@
 #  value         :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  collection_id :bigint           not null
+#  collection_id :bigint
 #
 # Indexes
 #

--- a/spec/models/app_preference_spec.rb
+++ b/spec/models/app_preference_spec.rb
@@ -10,7 +10,7 @@
 #  value         :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  collection_id :bigint           not null
+#  collection_id :bigint
 #
 # Indexes
 #

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -134,20 +134,38 @@ RSpec.describe AppPreferencesController, type: :request do
       expect(AppPreference.where(name: "collection_email_to_send_requests").pluck(:placeholder).uniq).to eq(["curator@example.edu"])
     end
 
-    it 'does not silently create app preferences when there are no collections' do
+    it 'stores app preferences without a collection and copies them when a collection is created later' do
       Collection.destroy_all
 
       post app_preferences_path, params: {
         app_preference: {
           name: "enable_dashboard_banner",
           description: "Enable dashboard banner",
-          pref_type: "boolean"
+          pref_type: "boolean",
+          placeholder: "Show on dashboard"
         }
       }, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
       expect(response).to have_http_status(:success)
-      expect(response.body).to include("Create a collection before creating App Preferences.")
-      expect(AppPreference.where(name: "enable_dashboard_banner")).to be_empty
+      expect(AppPreference.find_by!(name: "enable_dashboard_banner").collection_id).to be_nil
+
+      post collections_path, params: {
+        collection: {
+          division: "new_collection",
+          admin_group: "new-admins",
+          short_description: "New collection",
+          long_description: "New collection long description",
+          division_page_url: "https://example.edu/new_collection",
+          link_to_policies: "https://example.edu/new_collection/policies"
+        }
+      }
+
+      new_collection = Collection.find_by!(division: "new_collection")
+      new_preference = AppPreference.find_by!(collection: new_collection, name: "enable_dashboard_banner")
+
+      expect(new_preference.description).to eq("Enable dashboard banner")
+      expect(new_preference.pref_type).to eq("boolean")
+      expect(new_preference.placeholder).to eq("Show on dashboard")
     end
   end
 

--- a/spec/requests/app_preferences_controller_spec.rb
+++ b/spec/requests/app_preferences_controller_spec.rb
@@ -133,6 +133,22 @@ RSpec.describe AppPreferencesController, type: :request do
       expect(response).to have_http_status(:success)
       expect(AppPreference.where(name: "collection_email_to_send_requests").pluck(:placeholder).uniq).to eq(["curator@example.edu"])
     end
+
+    it 'does not silently create app preferences when there are no collections' do
+      Collection.destroy_all
+
+      post app_preferences_path, params: {
+        app_preference: {
+          name: "enable_dashboard_banner",
+          description: "Enable dashboard banner",
+          pref_type: "boolean"
+        }
+      }, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Create a collection before creating App Preferences.")
+      expect(AppPreference.where(name: "enable_dashboard_banner")).to be_empty
+    end
   end
 
   describe 'POST /app_preferences/app_prefs' do


### PR DESCRIPTION
Fixes the zero-collections App Preference edge case by allowing App Preference definitions to be stored before any collections exist.

**Changes**
- Allows AppPreference records to exist without a collection_id as template/default preferences.
- Stores a new App Preference with collection_id = nil when there are no collections.
- Copies those stored preference templates onto newly created collections.
- Includes placeholder when copying App Preferences to a new collection.
- Nil template preferences persist when collections are deleted, because dependent: :destroy only removes collection-scoped preference rows.
- Adds request coverage for creating an App Preference with no collections and applying it to a later collection.
- Updated seed file to include preference rows that match the new functionality (collection_id nil template rows with copied occupied collection_id rows)

All RSpec tests pass except for a minor UI hiccup that is being fixed in another PR, and app functionality is working as intended in local dev testing.