### PR TITLE
Update loan request confirmation page and flash message

### DIFF
--- a/app/controllers/loan_requests_controller.rb
+++ b/app/controllers/loan_requests_controller.rb
@@ -148,7 +148,7 @@ class LoanRequestsController < ApplicationController
         # Clean up checkout items
         clean_up_checkout_items
 
-        redirect_to checkout_path, notice: "Loan request sent with CSV and PDF attached."
+        redirect_to checkout_path, notice: "Loan request sent with CSV and PDF attached. Check your Profile for details."
       else
         flash[:alert] = "Failed to create loan request. Please try again: #{@loan_request.errors.full_messages.join(', ')}"
         redirect_to new_loan_request_path

--- a/app/views/loan_requests/step_five.html.erb
+++ b/app/views/loan_requests/step_five.html.erb
@@ -6,6 +6,9 @@
   <div>
     <%= render "profiles/user_loan_items" %>
   </div>
+  <p class="text-muted mt-3">
+    After your loan request is sent, these items will be removed from your checkout.
+  </p>
   <%= hidden_field_tag :shipping_address_id, @shipping_address.id %>
 
   <div class="d-flex justify-content-between align-items-center my-4">

--- a/spec/requests/loan_requests_controller_spec.rb
+++ b/spec/requests/loan_requests_controller_spec.rb
@@ -228,6 +228,7 @@ RSpec.describe LoanRequestsController, type: :request do
         get step_five_path, params: { shipping_address_id: address.id }
         expect(response).to have_http_status(:success)
         expect(response.body).to include("Items for Checkout")
+        expect(response.body).to include("After your loan request is sent, these items will be removed from your checkout.")
       end
     end
 
@@ -256,7 +257,7 @@ RSpec.describe LoanRequestsController, type: :request do
         }.to change(LoanRequest, :count).by(1)
 
         expect(response).to redirect_to(checkout_path)
-        expect(flash[:notice]).to eq('Loan request sent with CSV and PDF attached.')
+        expect(flash[:notice]).to eq('Loan request sent with CSV and PDF attached. Check your Profile for details.')
       end
 
       it 'assigns correct attributes to loan request' do


### PR DESCRIPTION
Updates the loan request confirmation page and flash message.
**Changes**
- Adds a note on the final loan request review page explaining that submitted items will be removed from checkout after the loan request is sent.
- Updates the success flash message after sending a loan request to include: “Check your Profile for details.”
- Updates request specs to cover the new final-page text and flash message.

All RSpec tests pass on local branch, and functionality works as intended.