### PR TITLE
Update flash message and make loan request checkout message more visible.

### DIFF
--- a/app/controllers/loan_requests_controller.rb
+++ b/app/controllers/loan_requests_controller.rb
@@ -148,7 +148,7 @@ class LoanRequestsController < ApplicationController
         # Clean up checkout items
         clean_up_checkout_items
 
-        redirect_to checkout_path, notice: "Loan request sent with CSV and PDF attached. Check your Profile for details."
+        redirect_to checkout_path, notice: "Loan request sent. Check your Profile for details."
       else
         flash[:alert] = "Failed to create loan request. Please try again: #{@loan_request.errors.full_messages.join(', ')}"
         redirect_to new_loan_request_path

--- a/app/views/loan_requests/step_five.html.erb
+++ b/app/views/loan_requests/step_five.html.erb
@@ -6,9 +6,9 @@
   <div>
     <%= render "profiles/user_loan_items" %>
   </div>
-  <p class="text-muted mt-3">
+  <div class="alert alert-info fw-semibold mt-3" role="status">
     After your loan request is sent, these items will be removed from your checkout.
-  </p>
+  </div>
   <%= hidden_field_tag :shipping_address_id, @shipping_address.id %>
 
   <div class="d-flex justify-content-between align-items-center my-4">

--- a/spec/requests/loan_requests_controller_spec.rb
+++ b/spec/requests/loan_requests_controller_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe LoanRequestsController, type: :request do
         }.to change(LoanRequest, :count).by(1)
 
         expect(response).to redirect_to(checkout_path)
-        expect(flash[:notice]).to eq('Loan request sent with CSV and PDF attached. Check your Profile for details.')
+        expect(flash[:notice]).to eq('Loan request sent. Check your Profile for details.')
       end
 
       it 'assigns correct attributes to loan request' do


### PR DESCRIPTION
Updates loan request confirmation messaging styles and text.
**Changes**
- Makes the final-page checkout removal notice more visible by displaying it as an information alert.
- Simplifies the success flash message to remove the “CSV and PDF” mentions.
- Keeps the profile guidance in the flash message: “Check your Profile for details.”
- Updates request specs for the revised messaging.