### PR TITLE
Add solid cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@
 !/app/assets/builds/.keep
 # Ignore Google site verification file
 public/google592431709e6edaf8.html
+
+.copilotignore

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ gem 'sentry-rails'
 gem 'country_select'
 gem 'concurrent-ruby', '~> 1.3'
 gem 'csv', '~> 3.3', '>= 3.3.5'
+gem 'solid_cache'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,6 +444,10 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     skylight (7.0.0)
       activesupport (>= 7.1.0)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -548,6 +552,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   skylight
+  solid_cache
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: addresses
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  address_line_1 :string

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: announcements
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  displayed  :boolean          default(FALSE), not null

--- a/app/models/app_preference.rb
+++ b/app/models/app_preference.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: app_preferences
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  description   :string

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: checkouts
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  created_at :datetime         not null

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collections
+# Database name: primary
 #
 #  id                :bigint           not null, primary key
 #  admin_group       :string

--- a/app/models/collection_answer.rb
+++ b/app/models/collection_answer.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_answers
+# Database name: primary
 #
 #  id                     :bigint           not null, primary key
 #  created_at             :datetime         not null

--- a/app/models/collection_option.rb
+++ b/app/models/collection_option.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_options
+# Database name: primary
 #
 #  id                     :bigint           not null, primary key
 #  value                  :string           not null

--- a/app/models/collection_question.rb
+++ b/app/models/collection_question.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_questions
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  position      :integer

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: faqs
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  position   :integer

--- a/app/models/global_preference.rb
+++ b/app/models/global_preference.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: global_preferences
+# Database name: primary
 #
 #  id          :bigint           not null, primary key
 #  description :string

--- a/app/models/identification.rb
+++ b/app/models/identification.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: identifications
+# Database name: primary
 #
 #  id                         :bigint           not null, primary key
 #  class_name                 :string

--- a/app/models/information_request.rb
+++ b/app/models/information_request.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: information_requests
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  checkout_items :string           default([]), is an Array

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: items
+# Database name: primary
 #
 #  id                               :bigint           not null, primary key
 #  associated_sequences             :string

--- a/app/models/item_import_log.rb
+++ b/app/models/item_import_log.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: item_import_logs
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  date          :datetime

--- a/app/models/loan_answer.rb
+++ b/app/models/loan_answer.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_answers
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  created_at       :datetime         not null

--- a/app/models/loan_question.rb
+++ b/app/models/loan_question.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_questions
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  position      :integer

--- a/app/models/loan_request.rb
+++ b/app/models/loan_request.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_requests
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  checkout_items :string           default([]), is an Array

--- a/app/models/map_field.rb
+++ b/app/models/map_field.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: map_fields
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  caption       :string

--- a/app/models/no_longer_available.rb
+++ b/app/models/no_longer_available.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: no_longer_availables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  collection       :string

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: options
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  value            :string

--- a/app/models/preparation.rb
+++ b/app/models/preparation.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: preparations
+# Database name: primary
 #
 #  id          :bigint           not null, primary key
 #  barcode     :string

--- a/app/models/requestable.rb
+++ b/app/models/requestable.rb
@@ -1,11 +1,13 @@
 # == Schema Information
 #
 # Table name: requestables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  collection       :string
 #  count            :integer
 #  item_name        :string
+#  loan_request     :boolean          default(TRUE), not null
 #  preparation_type :string
 #  saved_for_later  :boolean          default(FALSE), not null
 #  created_at       :datetime         not null

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: saved_searches
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  filters       :jsonb

--- a/app/models/search_statistic.rb
+++ b/app/models/search_statistic.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: search_statistics
+# Database name: primary
 #
 #  id                :bigint           not null, primary key
 #  field_label       :string           not null

--- a/app/models/unavailable.rb
+++ b/app/models/unavailable.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: unavailables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  preparation_type :string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: users
+# Database name: primary
 #
 #  id                     :bigint           not null, primary key
 #  affiliation            :string

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,25 @@
+default: &default
+  store_options:
+    # Cap age of oldest cache entry to fulfill retention policies
+    # max_age: <%= 60.days.to_i %>
+    max_size: <%= 256.megabytes %>
+    namespace: <%= Rails.env %>
+
+development:
+  database: cache
+  <<: *default
+
+test:
+  <<: *default
+
+phase2_staging:
+  database: cache
+  <<: *default
+
+staging:
+  database: cache
+  <<: *default
+
+production:
+  database: cache
+  <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,8 +15,13 @@ default: &default
     idle_session_timeout: 300s
 
 development:
-  <<: *default
-  database: biorepository_portal_development
+  primary:
+    <<: *default
+    database: biorepository_portal_development
+  cache:
+    <<: *default
+    database: biorepository_portal_development_cache
+    migrations_paths: db/cache_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -26,20 +31,35 @@ test:
   database: biorepository_portal_test
 
 staging:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 15 } %>
-  timeout: 10000
+  primary:
+    <<: *default
+    url: <%= ENV["DATABASE_URL"] %>
+    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 15 } %>
+    timeout: 10000
+  cache:
+    <<: *default
+    url: <%= ENV.fetch("CACHE_DATABASE_URL") { ENV["DATABASE_URL"] } %>
+    migrations_paths: db/cache_migrate
 
 phase2_staging:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 15 } %>
-  timeout: 10000
-  idle_session_timeout: 300s
+  primary:
+    <<: *default
+    url: <%= ENV["DATABASE_URL"] %>
+    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 15 } %>
+    timeout: 10000
+    idle_session_timeout: 300s
+  cache:
+    <<: *default
+    url: <%= ENV.fetch("CACHE_DATABASE_URL") { ENV["DATABASE_URL"] } %>
+    migrations_paths: db/cache_migrate
 
 production:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 15 } %>
-  timeout: 10000
+  primary:
+    <<: *default
+    url: <%= ENV["DATABASE_URL"] %>
+    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 15 } %>
+    timeout: 10000
+  cache:
+    <<: *default
+    url: <%= ENV.fetch("CACHE_DATABASE_URL") { ENV["DATABASE_URL"] } %>
+    migrations_paths: db/cache_migrate

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,10 +23,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
-    }
+    config.cache_store = :solid_cache_store
   else
     config.action_controller.perform_caching = false
 

--- a/config/environments/phase2_staging.rb
+++ b/config/environments/phase2_staging.rb
@@ -33,6 +33,9 @@ Rails.application.configure do
   #   config.cache_store = :null_store
   # end
   config.action_controller.perform_caching = true
+  # Use Solid Cache
+  config.cache_store = :solid_cache_store
+
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,9 +66,6 @@ Rails.application.configure do
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
-  # Use a different cache store in production.
-  config.cache_store = :solid_cache_store
-
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "biorepository_portal_production"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,6 +15,8 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
+  # Use Solid Cache
+  config.cache_store = :solid_cache_store
 
   # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
   # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
@@ -65,7 +67,7 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :solid_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -33,6 +33,8 @@ Rails.application.configure do
   #   config.cache_store = :null_store
   # end
   config.action_controller.perform_caching = true
+  # Use Solid Cache
+  config.cache_store = :solid_cache_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/db/cache_migrate/001_create_solid_cache_entries.rb
+++ b/db/cache_migrate/001_create_solid_cache_entries.rb
@@ -1,0 +1,15 @@
+class CreateSolidCacheEntries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :solid_cache_entries do |t|
+      t.binary :key, null: false
+      t.binary :value, null: false
+      t.datetime :created_at, null: false
+      t.bigint :key_hash, null: false
+      t.integer :byte_size, null: false
+
+      t.index :byte_size
+      t.index [ :key_hash, :byte_size ]
+      t.index :key_hash, unique: true
+    end
+  end
+end

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 1) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.integer "byte_size", null: false
+    t.datetime "created_at", null: false
+    t.binary "key", null: false
+    t.bigint "key_hash", null: false
+    t.binary "value", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: addresses
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  address_line_1 :string

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: announcements
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  displayed  :boolean          default(FALSE), not null

--- a/spec/factories/app_preferences.rb
+++ b/spec/factories/app_preferences.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: app_preferences
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  description   :string

--- a/spec/factories/checkouts.rb
+++ b/spec/factories/checkouts.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: checkouts
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  created_at :datetime         not null

--- a/spec/factories/collection_answers.rb
+++ b/spec/factories/collection_answers.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_answers
+# Database name: primary
 #
 #  id                     :bigint           not null, primary key
 #  created_at             :datetime         not null

--- a/spec/factories/collection_options.rb
+++ b/spec/factories/collection_options.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_options
+# Database name: primary
 #
 #  id                     :bigint           not null, primary key
 #  value                  :string           not null

--- a/spec/factories/collection_questions.rb
+++ b/spec/factories/collection_questions.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_questions
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  position      :integer

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collections
+# Database name: primary
 #
 #  id                :bigint           not null, primary key
 #  admin_group       :string

--- a/spec/factories/faqs.rb
+++ b/spec/factories/faqs.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: faqs
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  position   :integer

--- a/spec/factories/global_preferences.rb
+++ b/spec/factories/global_preferences.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: global_preferences
+# Database name: primary
 #
 #  id          :bigint           not null, primary key
 #  description :string

--- a/spec/factories/identifications.rb
+++ b/spec/factories/identifications.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: identifications
+# Database name: primary
 #
 #  id                         :bigint           not null, primary key
 #  class_name                 :string

--- a/spec/factories/information_requests.rb
+++ b/spec/factories/information_requests.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: information_requests
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  checkout_items :string           default([]), is an Array

--- a/spec/factories/item_import_logs.rb
+++ b/spec/factories/item_import_logs.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: item_import_logs
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  date          :datetime

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: items
+# Database name: primary
 #
 #  id                               :bigint           not null, primary key
 #  associated_sequences             :string

--- a/spec/factories/loan_answers.rb
+++ b/spec/factories/loan_answers.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_answers
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  created_at       :datetime         not null

--- a/spec/factories/loan_questions.rb
+++ b/spec/factories/loan_questions.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_questions
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  position      :integer

--- a/spec/factories/loan_requests.rb
+++ b/spec/factories/loan_requests.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_requests
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  checkout_items :string           default([]), is an Array

--- a/spec/factories/map_fields.rb
+++ b/spec/factories/map_fields.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: map_fields
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  caption       :string

--- a/spec/factories/no_longer_availables.rb
+++ b/spec/factories/no_longer_availables.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: no_longer_availables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  collection       :string

--- a/spec/factories/options.rb
+++ b/spec/factories/options.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: options
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  value            :string

--- a/spec/factories/preparations.rb
+++ b/spec/factories/preparations.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: preparations
+# Database name: primary
 #
 #  id          :bigint           not null, primary key
 #  barcode     :string

--- a/spec/factories/requestables.rb
+++ b/spec/factories/requestables.rb
@@ -1,11 +1,13 @@
 # == Schema Information
 #
 # Table name: requestables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  collection       :string
 #  count            :integer
 #  item_name        :string
+#  loan_request     :boolean          default(TRUE), not null
 #  preparation_type :string
 #  saved_for_later  :boolean          default(FALSE), not null
 #  created_at       :datetime         not null

--- a/spec/factories/saved_searches.rb
+++ b/spec/factories/saved_searches.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: saved_searches
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  filters       :jsonb

--- a/spec/factories/search_statistics.rb
+++ b/spec/factories/search_statistics.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: search_statistics
+# Database name: primary
 #
 #  id                :bigint           not null, primary key
 #  field_label       :string           not null

--- a/spec/factories/unavailables.rb
+++ b/spec/factories/unavailables.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: unavailables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  preparation_type :string

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: users
+# Database name: primary
 #
 #  id                     :bigint           not null, primary key
 #  affiliation            :string

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: addresses
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  address_line_1 :string

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: announcements
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  displayed  :boolean          default(FALSE), not null

--- a/spec/models/app_preference_spec.rb
+++ b/spec/models/app_preference_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: app_preferences
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  description   :string

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: checkouts
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  created_at :datetime         not null

--- a/spec/models/collection_answer_spec.rb
+++ b/spec/models/collection_answer_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_answers
+# Database name: primary
 #
 #  id                     :bigint           not null, primary key
 #  created_at             :datetime         not null

--- a/spec/models/collection_option_spec.rb
+++ b/spec/models/collection_option_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_options
+# Database name: primary
 #
 #  id                     :bigint           not null, primary key
 #  value                  :string           not null

--- a/spec/models/collection_question_spec.rb
+++ b/spec/models/collection_question_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collection_questions
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  position      :integer

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: collections
+# Database name: primary
 #
 #  id                :bigint           not null, primary key
 #  admin_group       :string

--- a/spec/models/faq_spec.rb
+++ b/spec/models/faq_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: faqs
+# Database name: primary
 #
 #  id         :bigint           not null, primary key
 #  position   :integer

--- a/spec/models/global_preference_spec.rb
+++ b/spec/models/global_preference_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: global_preferences
+# Database name: primary
 #
 #  id          :bigint           not null, primary key
 #  description :string

--- a/spec/models/identification_spec.rb
+++ b/spec/models/identification_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: identifications
+# Database name: primary
 #
 #  id                         :bigint           not null, primary key
 #  class_name                 :string

--- a/spec/models/information_request_spec.rb
+++ b/spec/models/information_request_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: information_requests
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  checkout_items :string           default([]), is an Array

--- a/spec/models/item_import_log_spec.rb
+++ b/spec/models/item_import_log_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: item_import_logs
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  date          :datetime

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: items
+# Database name: primary
 #
 #  id                               :bigint           not null, primary key
 #  associated_sequences             :string

--- a/spec/models/loan_answer_spec.rb
+++ b/spec/models/loan_answer_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_answers
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  created_at       :datetime         not null

--- a/spec/models/loan_question_spec.rb
+++ b/spec/models/loan_question_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_questions
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  position      :integer

--- a/spec/models/loan_request_spec.rb
+++ b/spec/models/loan_request_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: loan_requests
+# Database name: primary
 #
 #  id             :bigint           not null, primary key
 #  checkout_items :string           default([]), is an Array

--- a/spec/models/map_field_spec.rb
+++ b/spec/models/map_field_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: map_fields
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  caption       :string

--- a/spec/models/no_longer_available_spec.rb
+++ b/spec/models/no_longer_available_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: no_longer_availables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  collection       :string

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: options
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  value            :string

--- a/spec/models/preparation_spec.rb
+++ b/spec/models/preparation_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: preparations
+# Database name: primary
 #
 #  id          :bigint           not null, primary key
 #  barcode     :string

--- a/spec/models/requestable_spec.rb
+++ b/spec/models/requestable_spec.rb
@@ -1,11 +1,13 @@
 # == Schema Information
 #
 # Table name: requestables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  collection       :string
 #  count            :integer
 #  item_name        :string
+#  loan_request     :boolean          default(TRUE), not null
 #  preparation_type :string
 #  saved_for_later  :boolean          default(FALSE), not null
 #  created_at       :datetime         not null

--- a/spec/models/saved_search_spec.rb
+++ b/spec/models/saved_search_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: saved_searches
+# Database name: primary
 #
 #  id            :bigint           not null, primary key
 #  filters       :jsonb

--- a/spec/models/search_statistic_spec.rb
+++ b/spec/models/search_statistic_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: search_statistics
+# Database name: primary
 #
 #  id                :bigint           not null, primary key
 #  field_label       :string           not null

--- a/spec/models/unavailable_spec.rb
+++ b/spec/models/unavailable_spec.rb
@@ -1,6 +1,7 @@
 # == Schema Information
 #
 # Table name: unavailables
+# Database name: primary
 #
 #  id               :bigint           not null, primary key
 #  preparation_type :string


### PR DESCRIPTION
This pull request added Rails’ Solid Cache as the cache backend and wires it up to use a dedicated “cache” database configuration, alongside the existing primary database.

Changes:

- Add the solid_cache gem
- add migration db/cache_migrate/001_create_solid_cache_entries.rb
- check in the cache database schema (db/cache_schema.rb).
- Configure :solid_cache_store as the cache store for development (when caching is enabled), staging, phase2_staging, and production.
- Convert config/database.yml to a multi-database layout (primary + cache) 
- and add config/cache.yml for Solid Cache settings; 
- update schema annotations to include “Database name: primary”.
